### PR TITLE
Customize link href by block

### DIFF
--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -49,7 +49,7 @@ module Twitter
       auto_link_usernames_or_lists(
         auto_link_urls_custom(
           auto_link_hashtags(text, options),
-        options),
+        options), # FIXME It can expose internal options
       options)
     end
 
@@ -147,7 +147,7 @@ module Twitter
       text.gsub(Twitter::Regex[:valid_url]) do
         all, before, url, protocol, domain, path, query_string = $1, $2, $3, $4, $5, $6, $7
         if !protocol.blank?
-          html_attrs = tag_options(options.stringify_keys) || ""
+          html_attrs = tag_options(options.stringify_keys) || "" # FIXME It can expose internal options.
           "#{before}<a href=\"#{html_escape(url)}\"#{html_attrs}>#{html_escape(url)}</a>"
         else
           all

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -92,7 +92,12 @@ module Twitter
               # the link is a list
               chunk = list = "#{user}#{slash_listname}"
               chunk = yield(list) if block_given?
-              "#{before}#{at}<a class=\"#{options[:url_class]} #{options[:list_class]}\" #{target_tag(options)}href=\"#{html_escape(options[:list_url_base])}#{html_escape(list.downcase)}\"#{extra_html}>#{html_escape(chunk)}</a>"
+              href = if options[:list_url_block]
+                options[:list_url_block].call(list.downcase)
+              else
+                "#{html_escape(options[:list_url_base])}#{html_escape(list.downcase)}"
+              end
+              "#{before}#{at}<a class=\"#{options[:url_class]} #{options[:list_class]}\" #{target_tag(options)}href=\"#{href}\"#{extra_html}>#{html_escape(chunk)}</a>"
             else
               if after =~ Twitter::Regex[:end_screen_name_match]
                 # Followed by something that means we don't autolink
@@ -101,7 +106,12 @@ module Twitter
                 # this is a screen name
                 chunk = user
                 chunk = yield(chunk) if block_given?
-                "#{before}#{at}<a class=\"#{options[:url_class]} #{options[:username_class]}\" #{target_tag(options)}href=\"#{html_escape(options[:username_url_base])}#{html_escape(chunk)}\"#{extra_html}>#{html_escape(chunk)}</a>"
+                href = if options[:username_url_block]
+                  options[:username_url_block].call(chunk)
+                else
+                  "#{html_escape(options[:username_url_base])}#{html_escape(chunk)}"
+                end
+                "#{before}#{at}<a class=\"#{options[:url_class]} #{options[:username_class]}\" #{target_tag(options)}href=\"#{href}\"#{extra_html}>#{html_escape(chunk)}</a>"
               end
             end
           end
@@ -132,7 +142,12 @@ module Twitter
         hash = $2
         text = $3
         text = yield(text) if block_given?
-        "#{before}<a href=\"#{options[:hashtag_url_base]}#{html_escape(text)}\" title=\"##{html_escape(text)}\" #{target_tag(options)}class=\"#{options[:url_class]} #{options[:hashtag_class]}\"#{extra_html}>#{html_escape(hash)}#{html_escape(text)}</a>"
+        href = if options[:hashtag_url_block]
+          options[:hashtag_url_block].call(text)
+        else
+          "#{options[:hashtag_url_base]}#{html_escape(text)}"
+        end
+        "#{before}<a href=\"#{href}\" title=\"##{html_escape(text)}\" #{target_tag(options)}class=\"#{options[:url_class]} #{options[:hashtag_class]}\"#{extra_html}>#{html_escape(hash)}#{html_escape(text)}</a>"
       end
     end
 
@@ -147,8 +162,13 @@ module Twitter
       text.gsub(Twitter::Regex[:valid_url]) do
         all, before, url, protocol, domain, path, query_string = $1, $2, $3, $4, $5, $6, $7
         if !protocol.blank?
+          href = if options[:link_url_block]
+            options.delete(:link_url_block).call(url)
+          else
+            html_escape(url)
+          end
           html_attrs = tag_options(options.stringify_keys) || "" # FIXME It can expose internal options.
-          "#{before}<a href=\"#{html_escape(url)}\"#{html_attrs}>#{html_escape(url)}</a>"
+          "#{before}<a href=\"#{href}\"#{html_attrs}>#{html_escape(url)}</a>"
         else
           all
         end

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -547,6 +547,26 @@ describe Twitter::Autolink do
       linked.should have_autolinked_url('http://example.com/')
       linked.should match(/target="mywindow"/)
     end
+
+    it "should customize href by username_url_block option" do
+      linked = TestAutolink.new.auto_link("@test", :username_url_block => lambda{|a| "dummy"})
+      linked.should have_autolinked_url('dummy', 'test')
+    end
+
+    it "should customize href by list_url_block option" do
+      linked = TestAutolink.new.auto_link("@test/list", :list_url_block => lambda{|a| "dummy"})
+      linked.should have_autolinked_url('dummy', 'test/list')
+    end
+
+    it "should customize href by hashtag_url_block option" do
+      linked = TestAutolink.new.auto_link("#hashtag", :hashtag_url_block => lambda{|a| "dummy"})
+      linked.should have_autolinked_url('dummy', '#hashtag')
+    end
+
+    it "should customize href by link_url_block option" do
+      linked = TestAutolink.new.auto_link("http://example.com/", :link_url_block => lambda{|a| "dummy"})
+      linked.should have_autolinked_url('dummy', 'http://example.com/')
+    end
   end
 
   describe "html_escape" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,16 +32,16 @@ RSpec::Matchers.define :match_autolink_expression_in do |text|
   end
 end
 
-RSpec::Matchers.define :have_autolinked_url do |url|
+RSpec::Matchers.define :have_autolinked_url do |url, inner_text|
   match do |text|
     @link = Nokogiri::HTML(text).search("a[@href='#{url}']")
     @link &&
     @link.inner_text &&
-    @link.inner_text == url
+    (inner_text && @link.inner_text == inner_text) || (!inner_text && @link.inner_text == url)
   end
 
   failure_message_for_should do |text|
-    "Expected url '#{url}' to be autolinked in '#{text}'"
+    "Expected url '#{url}'#{", inner_text '#{inner_text}'" if inner_text} to be autolinked in '#{text}'"
   end
 end
 

--- a/test/conformance_test.rb
+++ b/test/conformance_test.rb
@@ -1,7 +1,7 @@
 require 'test/unit'
 require 'yaml'
 $KCODE = 'UTF8'
-require File.dirname(__FILE__) + '/../lib/twitter-text'
+require File.expand_path(File.dirname(__FILE__) + '/../lib/twitter-text')
 
 class ConformanceTest < Test::Unit::TestCase
   include Twitter::Extractor


### PR DESCRIPTION
Add {username, list, hashtag and link}_url_block options to customize href attributes rather than using {username, list, hashtag}_url_base + value style.
