### PR TITLE
Extract URLs without protocol

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,16 @@
 PATH
   remote: .
   specs:
-    twitter-text (1.4.8)
+    twitter-text (1.4.9)
       activesupport
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.0.3)
+    activesupport (3.1.0)
+      multi_json (~> 1.0)
     diff-lcs (1.1.2)
+    multi_json (1.0.4)
     nokogiri (1.4.4)
     nokogiri (1.4.4-java)
       weakling (>= 0.0.3)

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -155,9 +155,12 @@ module Twitter
       return [] unless text
       urls = []
       position = 0
-      text.to_s.scan(Twitter::Regex[:valid_url]) do |all, before, url, protocol, domain, path, query|
+      text.to_s.scan(Twitter::Regex[:valid_url]) do |all, before, url, protocol, domain, port, path, query|
         valid_url_match_data = $~
-        if protocol && !protocol.empty?
+
+        # Regex in Ruby 1.8 doesn't support lookbehind, so we need to manually filter out
+        # the short URLs without protocol and path, i.e., [domain].[ccTLD]
+        unless !protocol && !path && domain =~ Twitter::Regex[:valid_short_domain]
           start_position = valid_url_match_data.char_begin(3)
           end_position = valid_url_match_data.char_end(3)
           urls << {

--- a/lib/regex.rb
+++ b/lib/regex.rb
@@ -139,7 +139,7 @@ module Twitter
 
     REGEXEN[:valid_port_number] = /[0-9]+/
 
-    REGEXEN[:valid_general_url_path_chars] = /[a-z0-9!\*';:=\+\,\$\/%#\[\]\-_~|#{LATIN_ACCENTS}]/i
+    REGEXEN[:valid_general_url_path_chars] = /[a-z0-9!\*';:=\+\,\$\/%#\[\]\-_~&|#{LATIN_ACCENTS}]/i
     # Allow URL paths to contain balanced parens
     #  1. Used in Wikipedia URLs like /Primer_(film)
     #  2. Used in IIS sessions like /S(dfd346)/
@@ -183,7 +183,7 @@ module Twitter
       #{REGEXEN[:validate_url_unreserved]}|
       #{REGEXEN[:validate_url_pct_encoded]}|
       #{REGEXEN[:validate_url_sub_delims]}|
-      :|@
+      [:\|@]
     )/iox
 
     REGEXEN[:validate_url_scheme] = /(?:[a-z][a-z0-9+\-.]*)/i

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -74,7 +74,7 @@ module Twitter
       extracted.size == 1 && extracted.first == hashtag[1..-1]
     end
 
-    def valid_url?(url, unicode_domains=true)
+    def valid_url?(url, unicode_domains=true, require_protocol=true)
       return false if !url || url.empty?
 
       url_parts = url.match(Twitter::Regex[:validate_url_unencoded])
@@ -82,7 +82,8 @@ module Twitter
 
       scheme, authority, path, query, fragment = url_parts.captures
 
-      return false unless (valid_match?(scheme, Twitter::Regex[:validate_url_scheme]) && scheme.match(/\Ahttps?\Z/i) &&
+      return false unless ((!require_protocol ||
+                           (valid_match?(scheme, Twitter::Regex[:validate_url_scheme]) && scheme.match(/\Ahttps?\Z/i))) &&
                            valid_match?(path, Twitter::Regex[:validate_url_path]) &&
                            valid_match?(query, Twitter::Regex[:validate_url_query], true) &&
                            valid_match?(fragment, Twitter::Regex[:validate_url_fragment], true))

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -391,18 +391,18 @@ describe Twitter::Autolink do
         end
 
         context "balanced parens with a double quote inside" do
-          def url; "http://foo.bar/foo_(\")_bar" end
+          def url; "http://foo.com/foo_(\")_bar" end
 
           it "should be linked" do
-            @autolinked_text.should have_autolinked_url("http://foo.bar/foo_")
+            @autolinked_text.should have_autolinked_url("http://foo.com/foo_")
           end
         end
 
         context "balanced parens hiding XSS" do
-          def url; 'http://x.xx/("style="color:red"onmouseover="alert(1)' end
+          def url; 'http://x.xx.com/("style="color:red"onmouseover="alert(1)' end
 
           it "should be linked" do
-            @autolinked_text.should have_autolinked_url("http://x.xx/")
+            @autolinked_text.should have_autolinked_url("http://x.xx.com/")
           end
         end
       end
@@ -479,10 +479,10 @@ describe Twitter::Autolink do
 
       context "with a @ in a URL" do
         context "with XSS attack" do
-          def original_text; 'http://x.xx/@"style="color:pink"onmouseover=alert(1)//'; end
+          def original_text; 'http://x.xx.com/@"style="color:pink"onmouseover=alert(1)//'; end
 
           it "should not allow XSS follwing @" do
-            @autolinked_text.should have_autolinked_url('http://x.xx/')
+            @autolinked_text.should have_autolinked_url('http://x.xx.com/')
           end
         end
 

--- a/spec/rewriter_spec.rb
+++ b/spec/rewriter_spec.rb
@@ -432,19 +432,19 @@ describe Twitter::Rewriter do
       end
 
       context "balanced parens with a double quote inside" do
-        def url; "http://foo.bar/foo_(\")_bar" end
+        def url; "http://foo.bar.com/foo_(\")_bar" end
 
         it "should be rewritten" do
-          @block_args.should == ["http://foo.bar/foo_"];
+          @block_args.should == ["http://foo.bar.com/foo_"];
           @rewritten_text.should == "I found a neatness ([rewritten](\")_bar)"
         end
       end
 
       context "balanced parens hiding XSS" do
-        def url; 'http://x.xx/("style="color:red"onmouseover="alert(1)' end
+        def url; 'http://x.xx.com/("style="color:red"onmouseover="alert(1)' end
 
         it "should be rewritten" do
-          @block_args.should == ["http://x.xx/"];
+          @block_args.should == ["http://x.xx.com/"];
           @rewritten_text.should == 'I found a neatness ([rewritten]("style="color:red"onmouseover="alert(1))'
         end
       end
@@ -526,10 +526,10 @@ describe Twitter::Rewriter do
 
     context "with a @ in a URL" do
       context "with XSS attack" do
-        def original_text; 'http://x.xx/@"style="color:pink"onmouseover=alert(1)//'; end
+        def original_text; 'http://x.xx.com/@"style="color:pink"onmouseover=alert(1)//'; end
 
         it "should not allow XSS follwing @" do
-          @block_args.should == ["http://x.xx/"]
+          @block_args.should == ["http://x.xx.com/"]
           @rewritten_text.should == '[rewritten]@"style="color:pink"onmouseover=alert(1)//'
         end
       end

--- a/spec/test_urls.rb
+++ b/spec/test_urls.rb
@@ -26,14 +26,16 @@ module TestUrls
     "http://a_b.c-d.com",
     "http://a-b.b.com",
     "http://twitter-dash.com",
-    # "t.co/nwcLTFF"
+    "www.foobar.com",
+    "WWW.FOOBAR.COM",
+    "www.foobar.co.jp",
+    "http://t.co",
+    "t.co/nwcLTFF"
   ] unless defined?(TestUrls::VALID)
 
   INVALID = [
     "http://no-tld",
     "http://tld-too-short.x",
-    "www.foobar.com",
-    "WWW.FOOBAR.COM",
     "http://-doman_dash.com",
     "http://_leadingunderscore.twitter.com",
     "http://trailingunderscore_.twitter.com",

--- a/test/conformance_test.rb
+++ b/test/conformance_test.rb
@@ -50,7 +50,7 @@ class ConformanceTest < Test::Unit::TestCase
       run_conformance_test(File.join(@conformance_dir, 'extract.yml'), :urls) do |description, expected, input|
         assert_equal expected, extract_urls(input), description
         expected.each do |expected_url|
-          assert_equal true, valid_url?(expected_url), "expected url [#{expected_url}] not valid"
+          assert_equal true, valid_url?(expected_url, true, false), "expected url [#{expected_url}] not valid"
         end
       end
     end
@@ -148,6 +148,12 @@ class ConformanceTest < Test::Unit::TestCase
     def test_urls_validation_conformance
       run_conformance_test(File.join(@conformance_dir, 'validate.yml'), :urls) do |description, expected, input|
         assert_equal expected, valid_url?(input), description
+      end
+    end
+
+    def test_urls_without_protocol_validation_conformance
+      run_conformance_test(File.join(@conformance_dir, 'validate.yml'), :urls_without_protocol) do |description, expected, input|
+        assert_equal expected, valid_url?(input, true, false), description
       end
     end
 


### PR DESCRIPTION
This will allow twitter-text to extract URLs without protocol, and URLs with '&' and '|' in the path/query.
