### PR TITLE
Modify HASHTAG regex to extract hashtags before/after punctuations.

### DIFF
--- a/lib/regex.rb
+++ b/lib/regex.rb
@@ -97,13 +97,13 @@ module Twitter
       regex_range(0x2F800, 0x2FA1F), regex_range(0x3005), regex_range(0x303B) # Kanji (CJK supplement)
     ].join('').freeze
 
-    HASHTAG_BOUNDARY = /(?:\A|\z|#{REGEXEN[:spaces]}|「|」|。|、|\.|!|\?|！|？|,)/
+    HASHTAG_BOUNDARY = /(?:\A|\z|#{REGEXEN[:spaces]}|[「」。、.,!?！？:;"'])/
 
     # A hashtag must contain latin characters, numbers and underscores, but not all numbers.
     HASHTAG_ALPHA = /[a-z_#{LATIN_ACCENTS}#{NON_LATIN_HASHTAG_CHARS}#{CJ_HASHTAG_CHARACTERS}]/io
     HASHTAG_ALPHANUMERIC = /[a-z0-9_#{LATIN_ACCENTS}#{NON_LATIN_HASHTAG_CHARS}#{CJ_HASHTAG_CHARACTERS}]/io
 
-    HASHTAG = /(#{HASHTAG_BOUNDARY})(#|＃)(#{HASHTAG_ALPHANUMERIC}*#{HASHTAG_ALPHA}#{HASHTAG_ALPHANUMERIC}*)(?=#{HASHTAG_BOUNDARY})/io
+    HASHTAG = /(#{HASHTAG_BOUNDARY})(#|＃)(#{HASHTAG_ALPHANUMERIC}*#{HASHTAG_ALPHA}#{HASHTAG_ALPHANUMERIC}*)/io
 
     REGEXEN[:auto_link_hashtags] = /#{HASHTAG}/io
 

--- a/spec/extractor_spec.rb
+++ b/spec/extractor_spec.rb
@@ -228,11 +228,11 @@ describe Twitter::Extractor do
         end
 
         it "should not allow the multiplication character" do
-          @extractor.extract_hashtags("#pre#{Twitter::Unicode::U00D7}post").should == []
+          @extractor.extract_hashtags("#pre#{Twitter::Unicode::U00D7}post").should == ["pre"]
         end
 
         it "should not allow the division character" do
-          @extractor.extract_hashtags("#pre#{Twitter::Unicode::U00F7}post").should == []
+          @extractor.extract_hashtags("#pre#{Twitter::Unicode::U00F7}post").should == ["pre"]
         end
       end
 
@@ -240,6 +240,10 @@ describe Twitter::Extractor do
 
     it "should not extract numeric hashtags" do
       @extractor.extract_hashtags("#1234").should == []
+    end
+
+    it "should extract hashtag followed by punctuations" do
+      @extractor.extract_hashtags("#test1: #test2; #test3\"").should == ["test1", "test2" ,"test3"]
     end
   end
 
@@ -283,11 +287,11 @@ describe Twitter::Extractor do
         end
 
         it "should not allow the multiplication character" do
-          not_match_hashtag_in_text("#pre#{[0xd7].pack('U')}post")
+          match_hashtag_in_text("pre", "#pre#{[0xd7].pack('U')}post", 0)
         end
 
         it "should not allow the division character" do
-          not_match_hashtag_in_text("#pre#{[0xf7].pack('U')}post")
+          match_hashtag_in_text("pre", "#pre#{[0xf7].pack('U')}post", 0)
         end
       end
     end


### PR DESCRIPTION
This fixes a bug in HASHTAG regex, which prevents Extractor to extract hashtags before/after punctuations like ':' or ';'.
