### PR TITLE
Do not extract URL in hashtag.

### DIFF
--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -68,8 +68,9 @@ module Twitter
       return [] unless text
 
       possible_screen_names = []
-      text.to_s.scan(Twitter::Regex[:extract_mentions]) do |before, sn, after|
+      text.to_s.scan(Twitter::Regex[:extract_mentions]) do |before, sn|
         extract_mentions_match_data = $~
+        after = $'
         unless after =~ Twitter::Regex[:end_screen_name_match]
           start_position = extract_mentions_match_data.char_begin(2) - 1
           end_position = extract_mentions_match_data.char_end(2)
@@ -99,8 +100,9 @@ module Twitter
       return [] unless text
 
       possible_entries = []
-      text.to_s.scan(Twitter::Regex[:extract_mentions_or_lists]) do |before, sn, list_slug, after|
+      text.to_s.scan(Twitter::Regex[:extract_mentions_or_lists]) do |before, sn, list_slug|
         extract_mentions_match_data = $~
+        after = $'
         unless after =~ Twitter::Regex[:end_screen_name_match]
           start_position = extract_mentions_match_data.char_begin(2) - 1
           end_position = extract_mentions_match_data.char_end(list_slug.nil? ? 2 : 3)
@@ -130,6 +132,7 @@ module Twitter
 
       possible_screen_name = text.match(Twitter::Regex[:extract_reply])
       return unless possible_screen_name.respond_to?(:captures)
+      return if $' =~ Twitter::Regex[:end_screen_name_match]
       screen_name = possible_screen_name.captures.first
       yield screen_name if block_given?
       screen_name
@@ -208,10 +211,13 @@ module Twitter
       text.scan(Twitter::Regex[:auto_link_hashtags]) do |before, hash, hash_text|
         start_position = $~.char_begin(2)
         end_position = $~.char_end(3)
-        tags << {
-          :hashtag => hash_text,
-          :indices => [start_position, end_position]
-        }
+        after = $'
+        unless after =~ Twitter::Regex[:end_hashtag_match]
+          tags << {
+            :hashtag => hash_text,
+            :indices => [start_position, end_position]
+          }
+        end
       end
       tags.each{|tag| yield tag[:hashtag], tag[:indices].first, tag[:indices].last } if block_given?
       tags

--- a/lib/regex.rb
+++ b/lib/regex.rb
@@ -118,7 +118,7 @@ module Twitter
     REGEXEN[:auto_link_emoticon] = /(8\-\#|8\-E|\+\-\(|\`\@|\`O|\&lt;\|:~\(|\}:o\{|:\-\[|\&gt;o\&lt;|X\-\/|\[:-\]\-I\-|\/\/\/\/Ö\\\\\\\\|\(\|:\|\/\)|∑:\*\)|\( \| \))/
 
     # URL related hash regex collection
-    REGEXEN[:valid_preceding_chars] = /(?:[^-\/"'!=A-Z0-9_@＠\.#{INVALID_CHARACTERS.join('')}]|^)/io
+    REGEXEN[:valid_preceding_chars] = /(?:[^-\/"'!=A-Z0-9_@＠#＃\.#{INVALID_CHARACTERS.join('')}]|^)/io
 
     DOMAIN_VALID_CHARS = "[^[:punct:][:space:][:blank:][:cntrl:]#{INVALID_CHARACTERS.join('')}#{UNICODE_SPACES.join('')}]"
     REGEXEN[:valid_subdomain] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[_-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io

--- a/lib/regex.rb
+++ b/lib/regex.rb
@@ -50,11 +50,6 @@ module Twitter
     ].map{|cp| [cp].pack('U') }.freeze
     REGEXEN[:invalid_control_characters] = /[#{INVALID_CHARACTERS.join('')}]/o
 
-    REGEXEN[:at_signs] = /[@＠]/
-    REGEXEN[:extract_mentions] = /(^|[^a-zA-Z0-9_])#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})(?=(.|$))/o
-    REGEXEN[:extract_mentions_or_lists] = /(^|[^a-zA-Z0-9_])#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})(\/[a-zA-Z][a-zA-Z0-9_\-]{0,24})?(?=(.|$))/o
-    REGEXEN[:extract_reply] = /^(?:#{REGEXEN[:spaces]})*#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})/o
-
     major, minor, patch = RUBY_VERSION.split('.')
     if major.to_i >= 2 || major.to_i == 1 && minor.to_i >= 9 || (defined?(RUBY_ENGINE) && ["jruby", "rbx"].include?(RUBY_ENGINE))
       REGEXEN[:list_name] = /[a-zA-Z][a-zA-Z0-9_\-\u0080-\u00ff]{0,24}/
@@ -89,8 +84,6 @@ module Twitter
     ].join('').freeze
     REGEXEN[:latin_accents] = /[#{LATIN_ACCENTS}]+/o
 
-    REGEXEN[:end_screen_name_match] = /^(?:#{REGEXEN[:at_signs]}|#{REGEXEN[:latin_accents]}|:\/\/)/o
-
     CJ_HASHTAG_CHARACTERS = [
       regex_range(0x30A1, 0x30FA), regex_range(0x30FC, 0x30FE), # Katakana (full-width)
       regex_range(0xFF66, 0xFF9F), # Katakana (half-width)
@@ -113,6 +106,15 @@ module Twitter
     HASHTAG = /(#{HASHTAG_BOUNDARY})(#|＃)(#{HASHTAG_ALPHANUMERIC}*#{HASHTAG_ALPHA}#{HASHTAG_ALPHANUMERIC}*)/io
 
     REGEXEN[:auto_link_hashtags] = /#{HASHTAG}/io
+    # Used in Extractor and Rewriter for final filtering
+    REGEXEN[:end_hashtag_match] = /^(?:[#＃]|:\/\/)/o
+
+    REGEXEN[:at_signs] = /[@＠]/
+    REGEXEN[:extract_mentions] = /(^|[^a-zA-Z0-9_])#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})/o
+    REGEXEN[:extract_mentions_or_lists] = /(^|[^a-zA-Z0-9_])#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})(\/[a-zA-Z][a-zA-Z0-9_\-]{0,24})?/o
+    REGEXEN[:extract_reply] = /^(?:#{REGEXEN[:spaces]})*#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})/o
+    # Used in Extractor and Rewriter for final filtering
+    REGEXEN[:end_screen_name_match] = /^(?:#{REGEXEN[:at_signs]}|#{REGEXEN[:latin_accents]}|:\/\/)/o
 
     REGEXEN[:auto_link_usernames_or_lists] = /([^a-zA-Z0-9_]|^|RT:?)([@＠]+)([a-zA-Z0-9_]{1,20})(\/[a-zA-Z][a-zA-Z0-9_\-]{0,24})?/o
     REGEXEN[:auto_link_emoticon] = /(8\-\#|8\-E|\+\-\(|\`\@|\`O|\&lt;\|:~\(|\}:o\{|:\-\[|\&gt;o\&lt;|X\-\/|\[:-\]\-I\-|\/\/\/\/Ö\\\\\\\\|\(\|:\|\/\)|∑:\*\)|\( \| \))/

--- a/lib/rewriter.rb
+++ b/lib/rewriter.rb
@@ -42,10 +42,12 @@ module Twitter
 
     def rewrite_hashtags(text)
       text.to_s.gsub(Twitter::Regex[:auto_link_hashtags]) do
-        before = $1
-        hash = $2
-        hashtag = $3
-        "#{before}#{yield(hash, hashtag)}"
+        before, hash, hashtag, after = $1, $2, $3, $'
+        if after =~ Twitter::Regex[:end_hashtag_match]
+          "#{before}#{hash}#{hashtag}"
+        else
+          "#{before}#{yield(hash, hashtag)}"
+        end
       end
     end
 


### PR DESCRIPTION
The current twitter-text tries to extract URL in a hashtag. For example, it extract "test.com" as a URL from a text "#test.com"

With this change, twitter-text won't extract URL in a hashtag.
