### PR TITLE
Modify extract_urls_with_indices() to correctly extract URL w/o protocol 

### DIFF
--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -164,37 +164,29 @@ module Twitter
         # If protocol is missing and domain contains non-ASCII characters,
         # extract ASCII-only domains.
         if !protocol
-          ascii_domains = []
+          last_url = nil
+          last_url_invalid_match = nil
           domain.scan(Twitter::Regex[:valid_ascii_domain]) do |ascii_domain|
-            ascii_domain_match_data = $~
-            ascii_domains << {
-              :domain => ascii_domain,
-              :start_position => ascii_domain_match_data.char_begin(0),
-              :end_position => ascii_domain_match_data.char_end(0)
+            last_url = {
+              :url => ascii_domain,
+              :indices => [start_position + $~.char_begin(0),
+                           start_position + $~.char_end(0)]
             }
+            last_url_invalid_match = ascii_domain =~ Twitter::Regex[:invalid_short_domain]
+            urls << last_url unless last_url_invalid_match
           end
 
-          # if domain doesn't contain any ASCII domain, skip the entire url.
-          next if ascii_domains.empty?
+          # no ASCII-only domain found. Skip the entire URL
+          next unless last_url
 
-          last = ascii_domains[-1]
-          ascii_domains[0..-2].each do |ascii_domain|
-            urls << {
-              :url => ascii_domain[:domain],
-              :indices => [start_position + ascii_domain[:start_position],
-                           start_position + ascii_domain[:end_position]]
-            }
+          # last_url only contains domain. Need to add path and query if they exist.
+          if path
+            # last_url was not added. Add it to urls here.
+            urls << last_url if last_url_invalid_match
+            last_url[:url] = url.sub(domain, last_url[:url])
+            last_url[:indices][1] = end_position
           end
-          if last[:start_position] > 0
-            start_position += last[:start_position]
-            url.sub!(domain, last[:domain])
-            domain = last[:domain]
-          end
-        end
-
-        # Regex in Ruby 1.8 doesn't support lookbehind, so we need to manually filter out
-        # the short URLs without protocol and path, i.e., [domain].[ccTLD]
-        unless !protocol && !path && domain =~ Twitter::Regex[:valid_short_domain]
+        else
           urls << {
             :url => url,
             :indices => [start_position, end_position]

--- a/lib/regex.rb
+++ b/lib/regex.rb
@@ -150,7 +150,7 @@ module Twitter
     /iox
 
     # This is used in Extractor to filter out unwanted URLs.
-    REGEXEN[:valid_short_domain] = /^#{REGEXEN[:valid_domain_name]}#{REGEXEN[:valid_ccTLD]}$/io
+    REGEXEN[:invalid_short_domain] = /^#{REGEXEN[:valid_domain_name]}#{REGEXEN[:valid_ccTLD]}$/io
 
     REGEXEN[:valid_port_number] = /[0-9]+/
 


### PR DESCRIPTION
This fixes a bug in extract_urls_with_indices() to correctly extract URL w/o protocol in CJK text.

Current behavior: 
Twitter::Extractor.extract_urls_with_indices("twitter.comテストgoogle.com") 
=> [{:url=>"twitter.com", :indices=>[0, 25]}] 
# Only 1st URL is extracted. Also indices is incorrect.

Correct behavior: 
Twitter::Extractor.extract_urls_with_indices("twitter.comテストgoogle.com") 
=> [{:url=>"twitter.com", :indices=>[0, 11]}, {:url=>"google.com", :indices=>[14, 24]}] 
