### PR TITLE
Stricter extraction rule for t.co URLs

### DIFF
--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -193,7 +193,7 @@ module Twitter
           # In the case of t.co URLs, don't allow additional path characters
           if url =~ Twitter::Regex[:valid_tco_url]
             url = $&
-            end_position -= $'.size
+            end_position = start_position + url.char_length
           end
           urls << {
             :url => url,

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -190,6 +190,11 @@ module Twitter
             last_url[:indices][1] = end_position
           end
         else
+          # In the case of t.co URLs, don't allow additional path characters
+          if url =~ Twitter::Regex[:valid_tco_url]
+            url = $&
+            end_position -= $'.size
+          end
           urls << {
             :url => url,
             :indices => [start_position, end_position]

--- a/lib/regex.rb
+++ b/lib/regex.rb
@@ -150,6 +150,9 @@ module Twitter
       (?:#{REGEXEN[:valid_gTLD]}|#{REGEXEN[:valid_ccTLD]}|#{REGEXEN[:valid_punycode]})
     /iox
 
+    # This is used in Extractor for stricter t.co URL extraction
+    REGEXEN[:valid_tco_url] = /^https?:\/\/t\.co\/[a-z0-9]+/i
+
     # This is used in Extractor to filter out unwanted URLs.
     REGEXEN[:invalid_short_domain] = /^#{REGEXEN[:valid_domain_name]}#{REGEXEN[:valid_ccTLD]}$/io
 

--- a/spec/extractor_spec.rb
+++ b/spec/extractor_spec.rb
@@ -169,6 +169,27 @@ describe Twitter::Extractor do
         @extractor.extract_urls("http://tld-too-short.x").should == []
       end
     end
+
+    describe "t.co URLS" do
+      TestUrls::TCO.each do |url|
+        it "should only extract the t.co URL from the URL #{url}" do
+          extracted_urls = @extractor.extract_urls(url)
+          extracted_urls.size.should == 1
+          extracted_url = extracted_urls.first
+          extracted_url.should_not == url
+          extracted_url.should == url[0...20]
+        end
+
+        it "should match the t.co URL from the URL #{url} when it's embedded in other text" do
+          text = "Sweet url: #{url} I found. #awesome"
+          extracted_urls = @extractor.extract_urls(text)
+          extracted_urls.size.should == 1
+          extracted_url = extracted_urls.first
+          extracted_url.should_not == url
+          extracted_url.should == url[0...20]
+        end
+      end
+    end
   end
 
   describe "urls with indices" do
@@ -198,6 +219,31 @@ describe Twitter::Extractor do
     describe "invalid URLS" do
       it "does not link urls with invalid domains" do
         @extractor.extract_urls_with_indices("http://tld-too-short.x").should == []
+      end
+    end
+
+    describe "t.co URLS" do
+      TestUrls::TCO.each do |url|
+        it "should only extract the t.co URL from the URL #{url} and adjust indices correctly" do
+          extracted_urls = @extractor.extract_urls_with_indices(url)
+          extracted_urls.size.should == 1
+          extracted_url = extracted_urls.first
+          extracted_url[:url].should_not include(url)
+          extracted_url[:url].should include(url[0...20])
+          extracted_url[:indices].first.should == 0
+          extracted_url[:indices].last.should == 20
+        end
+
+        it "should match the t.co URL from the URL #{url} when it's embedded in other text" do
+          text = "Sweet url: #{url} I found. #awesome"
+          extracted_urls = @extractor.extract_urls_with_indices(text)
+          extracted_urls.size.should == 1
+          extracted_url = extracted_urls.first
+          extracted_url[:url].should_not include(url)
+          extracted_url[:url].should include(url[0...20])
+          extracted_url[:indices].first.should == 11
+          extracted_url[:indices].last.should == 31
+        end
       end
     end
   end

--- a/spec/test_urls.rb
+++ b/spec/test_urls.rb
@@ -52,6 +52,29 @@ module TestUrls
     "http://twitt#{[0x202B].pack('U')}er.com",
     "http://twitt#{[0x202C].pack('U')}er.com",
     "http://twitt#{[0x202D].pack('U')}er.com",
-    "http://twitt#{[0x202E].pack('U')}er.com",
+    "http://twitt#{[0x202E].pack('U')}er.com"
   ] unless defined?(TestUrls::INVALID)
+
+  TCO = [
+    "http://t.co/P53cv5yO!",
+    "http://t.co/fQJmiPGg***",
+    "http://t.co/pbY2NfTZ's",
+    "http://t.co/2vYHpAc5;",
+    "http://t.co/ulYGBYSo:",
+    "http://t.co/GeT4bSiw=win",
+    "http://t.co/8MkmHU0k+fun",
+    "http://t.co/TKLp64dY.yes,",
+    "http://t.co/8vuO27cI$$",
+    "http://t.co/rPYTvdA8/",
+    "http://t.co/WvtMw5ku%",
+    "http://t.co/8t7G3ddS#",
+    "http://t.co/nfHNJDV2/#!",
+    "http://t.co/gK6NOXHs[good]",
+    "http://t.co/dMrT0o1Y]bad",
+    "http://t.co/FNkPfmii-",
+    "http://t.co/sMgS3pjI_oh",
+    "http://t.co/F8Dq3Plb~",
+    "http://t.co/ivvH58vC&help",
+    "http://t.co/iUBL15zD|NZ5KYLQ8"
+  ] unless defined?(TestUrls::TCO)
 end


### PR DESCRIPTION
I'm updating Twitter::Extractor to properly extract t.co URLs with trailing characters.  The extractor needs to be t.co aware because t.co supports fewer valid path characters than those matched by the valid_general_url_path_chars regular expression.  This causes legitimate URLs to be mistakenly identified on read once we swap them out for t.co URLs.  For instance:

> Twitter::Extractor.extract_urls("I like twitter.com's website")
>  => ["twitter.com"] 

If we replace the URL with a t.co URL, then we end up with:

> Twitter::Extractor.extract_urls("I like http://t.co/asdf's website")
>  => ["http://t.co/asdf's"] 

This is because ' is considered a valid path character, but it's not a valid domain character.  This patch strips out any non-word characters following the slug for t.co URLs.
