### PR TITLE
Adding $ as an invalid preceding char for domain names

### DIFF
--- a/lib/regex.rb
+++ b/lib/regex.rb
@@ -119,7 +119,7 @@ module Twitter
     REGEXEN[:auto_link_emoticon] = /(8\-\#|8\-E|\+\-\(|\`\@|\`O|\&lt;\|:~\(|\}:o\{|:\-\[|\&gt;o\&lt;|X\-\/|\[:-\]\-I\-|\/\/\/\/Ö\\\\\\\\|\(\|:\|\/\)|∑:\*\)|\( \| \))/
 
     # URL related hash regex collection
-    REGEXEN[:valid_preceding_chars] = /(?:[^-\/"'!=A-Z0-9_@＠#＃\.#{INVALID_CHARACTERS.join('')}]|^)/io
+    REGEXEN[:valid_preceding_chars] = /(?:[^-\/"'!=A-Z0-9_@＠\$#＃\.#{INVALID_CHARACTERS.join('')}]|^)/io
 
     DOMAIN_VALID_CHARS = "[^[:punct:][:space:][:blank:][:cntrl:]#{INVALID_CHARACTERS.join('')}#{UNICODE_SPACES.join('')}]"
     REGEXEN[:valid_subdomain] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[_-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io


### PR DESCRIPTION
This two-character patch prevents a string being identified as a link if the domain name is preceded by a $ symbol.

It's a common Twitter convention when talking about stocks to precede the ticker symbol with a dollar sign, e.g. $AAPL. When talking about stocks on other exchanges, the name of the exchange is sometimes appended to the symbol, e.g. when talking about Canadian stocks, you might use $TVI.TO (for Toronto exchange) or $RBS.CA (meaning Canada).

The current twitter-text-rb correctly identifies "tvi.to" and "rbs.ca" as potentially valid domain names. However, when preceded by a dollar sign this should not happen, otherwise "tvi.to" etc. will get converted into links or shortened URLs in some circumstances.
