### PR TITLE
autolink.rb#html_attrs was being overriden by the haml gem

### DIFF
--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -179,10 +179,10 @@ module Twitter
     BOOLEAN_ATTRIBUTES = Set.new([:disabled, :readonly, :multiple, :checked]).freeze
 
     def html_attrs_for_options(options)
-      html_attrs options.reject{|k, v| OPTIONS_NOT_ATTRIBUTES.include?(k)}
+      autolink_html_attrs options.reject{|k, v| OPTIONS_NOT_ATTRIBUTES.include?(k)}
     end
 
-    def html_attrs(options)
+    def autolink_html_attrs(options)
       options.inject("") do |attrs, (key, value)|
         if BOOLEAN_ATTRIBUTES.include?(key)
           value = value ? key : nil


### PR DESCRIPTION
the "haml" gem has a helper method called "html_attrs" which was conflicting with twitter-text-rb's html_attrs method.

https://github.com/nex3/haml/blob/master/lib/haml/helpers.rb#L198

So when I would auto_link in application_helper, any regular links would be corrupted:

text = "#foo http://google.com"
auto_link(text) =>

"<a href=\"http://twitter.com/search?q=%23foo\" title=\"#foo\" class=\"tweet-url hashtag\" rel=\"nofollow\">#foo</a> <a href=\"http://google.com\"{:xmlns=>\"http://www.w3.org/1999/xhtml\", \"xml:lang\"=<{:rel=>\"nofollow\", :class=<nil}, :lang=>{:rel=<\"nofollow\", :class=>nil}}http://google.com/a<"]
