### PR TITLE
Consolidate extract_mentions* and autolink_username* regex patterns into valid_mention*

### DIFF
--- a/lib/regex.rb
+++ b/lib/regex.rb
@@ -104,23 +104,24 @@ module Twitter
 
     HASHTAG = /(#{HASHTAG_BOUNDARY})(#|＃)(#{HASHTAG_ALPHANUMERIC}*#{HASHTAG_ALPHA}#{HASHTAG_ALPHANUMERIC}*)/io
 
-    REGEXEN[:auto_link_hashtags] = /#{HASHTAG}/io
+    REGEXEN[:valid_hashtag] = /#{HASHTAG}/io
     # Used in Extractor and Rewriter for final filtering
     REGEXEN[:end_hashtag_match] = /\A(?:[#＃]|:\/\/)/o
 
+    REGEXEN[:valid_mention_preceding_chars] = /(?:[^a-zA-Z0-9_]|^|RT:?)/o
     REGEXEN[:at_signs] = /[@＠]/
-    REGEXEN[:extract_mentions] = /(^|[^a-zA-Z0-9_])#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})/o
-    REGEXEN[:extract_mentions_or_lists] = /(^|[^a-zA-Z0-9_])#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})(\/[a-zA-Z][a-zA-Z0-9_\-]{0,24})?/o
-    REGEXEN[:extract_reply] = /^(?:#{REGEXEN[:spaces]})*#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})/o
+    REGEXEN[:valid_mention_or_list] = /
+      (#{REGEXEN[:valid_mention_preceding_chars]})  # $1: Preceeding character
+      (#{REGEXEN[:at_signs]})                       # $2: At mark
+      ([a-zA-Z0-9_]{1,20})                          # $3: Screen name
+      (\/[a-zA-Z][a-zA-Z0-9_\-]{0,24})?             # $4: List (optional)
+    /ox
+    REGEXEN[:valid_reply] = /^(?:#{REGEXEN[:spaces]})*#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})/o
     # Used in Extractor and Rewriter for final filtering
-    REGEXEN[:end_screen_name_match] = /\A(?:#{REGEXEN[:at_signs]}|#{REGEXEN[:latin_accents]}|:\/\/)/o
-
-    REGEXEN[:auto_link_usernames_or_lists] = /([^a-zA-Z0-9_]|^|RT:?)([@＠]+)([a-zA-Z0-9_]{1,20})(\/[a-zA-Z][a-zA-Z0-9_\-]{0,24})?/o
-    REGEXEN[:auto_link_emoticon] = /(8\-\#|8\-E|\+\-\(|\`\@|\`O|\&lt;\|:~\(|\}:o\{|:\-\[|\&gt;o\&lt;|X\-\/|\[:-\]\-I\-|\/\/\/\/Ö\\\\\\\\|\(\|:\|\/\)|∑:\*\)|\( \| \))/
+    REGEXEN[:end_mention_match] = /\A(?:#{REGEXEN[:at_signs]}|#{REGEXEN[:latin_accents]}|:\/\/)/o
 
     # URL related hash regex collection
-    REGEXEN[:valid_preceding_chars] = /(?:[^-\/"'!=A-Z0-9_@＠\$#＃\.#{INVALID_CHARACTERS.join('')}]|^)/io
-
+    REGEXEN[:valid_url_preceding_chars] = /(?:[^-\/"'!=A-Z0-9_@＠\$#＃\.#{INVALID_CHARACTERS.join('')}]|^)/io
     DOMAIN_VALID_CHARS = "[^[:punct:][:space:][:blank:][:cntrl:]#{INVALID_CHARACTERS.join('')}#{UNICODE_SPACES.join('')}]"
     REGEXEN[:valid_subdomain] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[_-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io
     REGEXEN[:valid_domain_name] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io
@@ -179,7 +180,7 @@ module Twitter
     REGEXEN[:valid_url_query_ending_chars] = /[a-z0-9_&=#\/]/i
     REGEXEN[:valid_url] = %r{
       (                                                                                     #   $1 total match
-        (#{REGEXEN[:valid_preceding_chars]})                                                #   $2 Preceeding chracter
+        (#{REGEXEN[:valid_url_preceding_chars]})                                            #   $2 Preceeding chracter
         (                                                                                   #   $3 URL
           (https?:\/\/)?                                                                    #   $4 Protocol (optional)
           (#{REGEXEN[:valid_domain]})                                                       #   $5 Domain(s)

--- a/lib/rewriter.rb
+++ b/lib/rewriter.rb
@@ -19,13 +19,13 @@ module Twitter
         if index % 4 != 0
           new_text << chunk
         else
-          new_text << chunk.gsub(Twitter::Regex[:auto_link_usernames_or_lists]) do
+          new_text << chunk.gsub(Twitter::Regex[:valid_mention_or_list]) do
             before, at, user, slash_listname, after = $1, $2, $3, $4, $'
             if slash_listname
               # the link is a list
               "#{before}#{yield(at, user, slash_listname)}"
             else
-              if after =~ Twitter::Regex[:end_screen_name_match]
+              if after =~ Twitter::Regex[:end_mention_match]
                 # Followed by something that means we don't autolink
                 "#{before}#{at}#{user}#{slash_listname}"
               else
@@ -41,7 +41,7 @@ module Twitter
     end
 
     def rewrite_hashtags(text)
-      text.to_s.gsub(Twitter::Regex[:auto_link_hashtags]) do
+      text.to_s.gsub(Twitter::Regex[:valid_hashtag]) do
         before, hash, hashtag, after = $1, $2, $3, $'
         if after =~ Twitter::Regex[:end_hashtag_match]
           "#{before}#{hash}#{hashtag}"

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -52,7 +52,7 @@ module Twitter
       extracted.size == 1 && extracted.first == username[1..-1]
     end
 
-    VALID_LIST_RE = /\A#{Twitter::Regex[:auto_link_usernames_or_lists]}\z/o
+    VALID_LIST_RE = /\A#{Twitter::Regex[:valid_mention_or_list]}\z/o
     def valid_list?(username_list)
       match = username_list.match(VALID_LIST_RE)
       # Must have matched and had nothing before or after


### PR DESCRIPTION
There are almost identical but slightly different regex patterns for extracting at_mention/list and auto-linking at_mention/list. Because of the difference, at_mention/list preceded by "RT" or "RT:" is auto-linked, but not extracted as entity.

This will consolidate extract_mentions\* and autolink_username\* regex patterns into a single valid_mention_or_list, and use it both in auto-linking and extracting at-mentions/lists. This makes the behavior of auto-linker and extractor consistent.
