### PR TITLE
Option to include '@' symbol as part of a link

### DIFF
--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -84,6 +84,9 @@ module Twitter
       extra_html = HTML_ATTR_NO_FOLLOW unless options[:suppress_no_follow]
 
       Twitter::Rewriter.rewrite_usernames_or_lists(text) do |at, username, slash_listname|
+        if options[:username_include_symbol]
+          username, at = "#{at}#{username}", nil
+        end
         name = "#{username}#{slash_listname}"
         chunk = block_given? ? yield(name) : name
 
@@ -93,23 +96,14 @@ module Twitter
           else
             "#{html_escape(options[:list_url_base])}#{html_escape(name.downcase)}"
           end
-          if !options[:username_include_symbol]
-            %(#{at}<a class="#{options[:url_class]} #{options[:list_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
-          else
-            %(<a class="#{options[:url_class]} #{options[:list_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{at}#{html_escape(chunk)}</a>)
-          end
+          %(#{at}<a class="#{options[:url_class]} #{options[:list_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
         else
           href = if options[:username_url_block]
             options[:username_url_block].call(chunk)
           else
             "#{html_escape(options[:username_url_base])}#{html_escape(chunk)}"
           end
-
-          if !options[:username_include_symbol]
-            %(#{at}<a class="#{options[:url_class]} #{options[:username_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
-          else
-            %(<a class="#{options[:url_class]} #{options[:username_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{at}#{html_escape(chunk)}</a>)
-          end
+          %(#{at}<a class="#{options[:url_class]} #{options[:username_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
         end
       end
     end

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -47,6 +47,7 @@ module Twitter
     # <tt>:username_url_base</tt>::      the value for <tt>href</tt> attribute on username links. The <tt>@username</tt> (minus the <tt>@</tt>) will be appended at the end of this.
     # <tt>:list_url_base</tt>::      the value for <tt>href</tt> attribute on list links. The <tt>@username/list</tt> (minus the <tt>@</tt>) will be appended at the end of this.
     # <tt>:hashtag_url_base</tt>::      the value for <tt>href</tt> attribute on hashtag links. The <tt>#hashtag</tt> (minus the <tt>#</tt>) will be appended at the end of this.
+    # <tt>:include_symbol</tt>::    place the <tt>@</tt> symbol within the link.
     # <tt>:suppress_lists</tt>::    disable auto-linking to lists
     # <tt>:suppress_no_follow</tt>::   Do not add <tt>rel="nofollow"</tt> to auto-linked items
     # <tt>:target</tt>::   add <tt>target="window_name"</tt> to auto-linked items
@@ -67,6 +68,7 @@ module Twitter
     # <tt>:username_class</tt>::    class to add to username <tt><a></tt> tags
     # <tt>:username_url_base</tt>::      the value for <tt>href</tt> attribute on username links. The <tt>@username</tt> (minus the <tt>@</tt>) will be appended at the end of this.
     # <tt>:list_url_base</tt>::      the value for <tt>href</tt> attribute on list links. The <tt>@username/list</tt> (minus the <tt>@</tt>) will be appended at the end of this.
+    # <tt>:include_symbol</tt>::    place the <tt>@</tt> symbol within the link.
     # <tt>:suppress_lists</tt>::    disable auto-linking to lists
     # <tt>:suppress_no_follow</tt>::   Do not add <tt>rel="nofollow"</tt> to auto-linked items
     # <tt>:target</tt>::   add <tt>target="window_name"</tt> to auto-linked items
@@ -91,14 +93,23 @@ module Twitter
           else
             "#{html_escape(options[:list_url_base])}#{html_escape(name.downcase)}"
           end
-          %(#{at}<a class="#{options[:url_class]} #{options[:list_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
+          if !options[:include_symbol]
+            %(#{at}<a class="#{options[:url_class]} #{options[:list_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
+          else
+            %(<a class="#{options[:url_class]} #{options[:list_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{at}#{html_escape(chunk)}</a>)
+          end
         else
           href = if options[:username_url_block]
             options[:username_url_block].call(chunk)
           else
             "#{html_escape(options[:username_url_base])}#{html_escape(chunk)}"
           end
-          %(#{at}<a class="#{options[:url_class]} #{options[:username_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
+
+          if !options[:include_symbol]
+            %(#{at}<a class="#{options[:url_class]} #{options[:username_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
+          else
+            %(<a class="#{options[:url_class]} #{options[:username_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{at}#{html_escape(chunk)}</a>)
+          end
         end
       end
     end

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -20,7 +20,7 @@ module Twitter
     OPTIONS_NOT_ATTRIBUTES = [:url_class, :list_class, :username_class, :hashtag_class,
                               :username_url_base, :list_url_base, :hashtag_url_base,
                               :username_url_block, :list_url_block, :hashtag_url_block, :link_url_block,
-                              :suppress_lists, :suppress_no_follow, :url_entities]
+                              :username_include_symbol, :suppress_lists, :suppress_no_follow, :url_entities]
 
     HTML_ENTITIES = {
       '&' => '&amp;',
@@ -47,7 +47,7 @@ module Twitter
     # <tt>:username_url_base</tt>::      the value for <tt>href</tt> attribute on username links. The <tt>@username</tt> (minus the <tt>@</tt>) will be appended at the end of this.
     # <tt>:list_url_base</tt>::      the value for <tt>href</tt> attribute on list links. The <tt>@username/list</tt> (minus the <tt>@</tt>) will be appended at the end of this.
     # <tt>:hashtag_url_base</tt>::      the value for <tt>href</tt> attribute on hashtag links. The <tt>#hashtag</tt> (minus the <tt>#</tt>) will be appended at the end of this.
-    # <tt>:include_symbol</tt>::    place the <tt>@</tt> symbol within the link.
+    # <tt>:username_include_symbol</tt>::    place the <tt>@</tt> symbol within username and list links
     # <tt>:suppress_lists</tt>::    disable auto-linking to lists
     # <tt>:suppress_no_follow</tt>::   Do not add <tt>rel="nofollow"</tt> to auto-linked items
     # <tt>:target</tt>::   add <tt>target="window_name"</tt> to auto-linked items
@@ -67,8 +67,8 @@ module Twitter
     # <tt>:list_class</tt>::    class to add to list <tt><a></tt> tags
     # <tt>:username_class</tt>::    class to add to username <tt><a></tt> tags
     # <tt>:username_url_base</tt>::      the value for <tt>href</tt> attribute on username links. The <tt>@username</tt> (minus the <tt>@</tt>) will be appended at the end of this.
+    # <tt>:username_include_symbol</tt>::    place the <tt>@</tt> symbol within username and list links
     # <tt>:list_url_base</tt>::      the value for <tt>href</tt> attribute on list links. The <tt>@username/list</tt> (minus the <tt>@</tt>) will be appended at the end of this.
-    # <tt>:include_symbol</tt>::    place the <tt>@</tt> symbol within the link.
     # <tt>:suppress_lists</tt>::    disable auto-linking to lists
     # <tt>:suppress_no_follow</tt>::   Do not add <tt>rel="nofollow"</tt> to auto-linked items
     # <tt>:target</tt>::   add <tt>target="window_name"</tt> to auto-linked items
@@ -93,7 +93,7 @@ module Twitter
           else
             "#{html_escape(options[:list_url_base])}#{html_escape(name.downcase)}"
           end
-          if !options[:include_symbol]
+          if !options[:username_include_symbol]
             %(#{at}<a class="#{options[:url_class]} #{options[:list_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
           else
             %(<a class="#{options[:url_class]} #{options[:list_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{at}#{html_escape(chunk)}</a>)
@@ -105,7 +105,7 @@ module Twitter
             "#{html_escape(options[:username_url_base])}#{html_escape(chunk)}"
           end
 
-          if !options[:include_symbol]
+          if !options[:username_include_symbol]
             %(#{at}<a class="#{options[:url_class]} #{options[:username_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
           else
             %(<a class="#{options[:url_class]} #{options[:username_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{at}#{html_escape(chunk)}</a>)

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -84,9 +84,9 @@ module Twitter
       extra_html = HTML_ATTR_NO_FOLLOW unless options[:suppress_no_follow]
 
       Twitter::Rewriter.rewrite_usernames_or_lists(text) do |at, username, slash_listname|
-        if options[:username_include_symbol]
-          username, at = "#{at}#{username}", nil
-        end
+        at_before_user = options[:username_include_symbol] ? at : ''
+        at = options[:username_include_symbol] ? '' : at
+
         name = "#{username}#{slash_listname}"
         chunk = block_given? ? yield(name) : name
 
@@ -94,16 +94,16 @@ module Twitter
           href = if options[:list_url_block]
             options[:list_url_block].call(name.downcase)
           else
-            "#{html_escape(options[:list_url_base])}#{html_escape(name.downcase)}"
+            "#{html_escape(options[:list_url_base] + name.downcase)}"
           end
-          %(#{at}<a class="#{options[:url_class]} #{options[:list_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
+          %(#{at}<a class="#{options[:url_class]} #{options[:list_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(at_before_user + chunk)}</a>)
         else
           href = if options[:username_url_block]
             options[:username_url_block].call(chunk)
           else
-            "#{html_escape(options[:username_url_base])}#{html_escape(chunk)}"
+            "#{html_escape(options[:username_url_base] + chunk)}"
           end
-          %(#{at}<a class="#{options[:url_class]} #{options[:username_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
+          %(#{at}<a class="#{options[:url_class]} #{options[:username_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(at_before_user + chunk)}</a>)
         end
       end
     end

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -558,13 +558,13 @@ describe Twitter::Autolink do
       linked.should match(/nofollow/)
     end
 
-    it "should include the '@' symbol in a username when passed :include_symbol" do
-      linked = TestAutolink.new.auto_link("@user", :include_symbol => true)
+    it "should include the '@' symbol in a username when passed :username_include_symbol" do
+      linked = TestAutolink.new.auto_link("@user", :username_include_symbol => true)
       linked.should link_to_screen_name('user', '@user')
     end
 
-    it "should include the '@' symbol in a list when passed :include_symbol" do
-      linked = TestAutolink.new.auto_link("@user/list", :include_symbol => true)
+    it "should include the '@' symbol in a list when passed :username_include_symbol" do
+      linked = TestAutolink.new.auto_link("@user/list", :username_include_symbol => true)
       linked.should link_to_list_path('user/list', '@user/list')
     end
 

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -558,6 +558,16 @@ describe Twitter::Autolink do
       linked.should match(/nofollow/)
     end
 
+    it "should include the '@' symbol in a username when passed :include_symbol" do
+      linked = TestAutolink.new.auto_link("@user", :include_symbol => true)
+      linked.should link_to_screen_name('user', '@user')
+    end
+
+    it "should include the '@' symbol in a list when passed :include_symbol" do
+      linked = TestAutolink.new.auto_link("@user/list", :include_symbol => true)
+      linked.should link_to_list_path('user/list', '@user/list')
+    end
+
     it "should not add rel=nofollow when passed :suppress_no_follow" do
       linked = TestAutolink.new.auto_link("http://example.com/", :suppress_no_follow => true)
       linked.should have_autolinked_url('http://example.com/')

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -560,12 +560,12 @@ describe Twitter::Autolink do
 
     it "should include the '@' symbol in a username when passed :username_include_symbol" do
       linked = TestAutolink.new.auto_link("@user", :username_include_symbol => true)
-      linked.should link_to_screen_name('user', '@user')
+      linked.should link_to_screen_name('@user')
     end
 
     it "should include the '@' symbol in a list when passed :username_include_symbol" do
       linked = TestAutolink.new.auto_link("@user/list", :username_include_symbol => true)
-      linked.should link_to_list_path('user/list', '@user/list')
+      linked.should link_to_list_path('@user/list')
     end
 
     it "should not add rel=nofollow when passed :suppress_no_follow" do

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -560,12 +560,12 @@ describe Twitter::Autolink do
 
     it "should include the '@' symbol in a username when passed :username_include_symbol" do
       linked = TestAutolink.new.auto_link("@user", :username_include_symbol => true)
-      linked.should link_to_screen_name('@user')
+      linked.should link_to_screen_name('user', '@user')
     end
 
     it "should include the '@' symbol in a list when passed :username_include_symbol" do
       linked = TestAutolink.new.auto_link("@user/list", :username_include_symbol => true)
-      linked.should link_to_list_path('@user/list')
+      linked.should link_to_list_path('user/list', '@user/list')
     end
 
     it "should not add rel=nofollow when passed :suppress_no_follow" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,15 +54,21 @@ end
 RSpec::Matchers.define :link_to_screen_name do |screen_name|
   match do |text|
     @link = Nokogiri::HTML(text).search("a.username")
-    @link && @link.inner_text == screen_name && "http://twitter.com/#{screen_name}".downcase.should == @link.first['href']
+    @link &&
+    @link.inner_text == screen_name &&
+    "http://twitter.com/#{screen_name}".downcase.should == @link.first['href']
   end
 
   failure_message_for_should do |text|
-    "expected link #{@link.inner_text} with href #{@link['href']} to match screen_name #{@screen_name}, but it does not"
+    if @link.first
+      "Expected link '#{@link.inner_text}' with href '#{@link.first['href']}' to match screen_name '#{screen_name}', but it does not."
+    else
+      "Expected screen name '#{screen_name}' to be autolinked in '#{text}', but no link was found."
+    end
   end
 
   failure_message_for_should_not do |text|
-    "expected link #{@link.inner_text} with href #{@link['href']} not to match screen_name #{@screen_name}, but it does"
+    "Expected link '#{@link.inner_text}' with href '#{@link.first['href']}' not to match screen_name '#{screen_name}', but it does."
   end
 
   description do
@@ -73,15 +79,21 @@ end
 RSpec::Matchers.define :link_to_list_path do |list_path|
   match do |text|
     @link = Nokogiri::HTML(text).search("a.list-slug")
-    !@link.nil? && @link.inner_text == list_path && "http://twitter.com/#{list_path}".downcase.should == @link.first['href']
+    @link &&
+    @link.inner_text == list_path &&
+    "http://twitter.com/#{list_path}".downcase.should == @link.first['href']
   end
 
   failure_message_for_should do |text|
-    "expected link #{@link.inner_text} with href #{@link['href']} to match the list path #{list_path}, but it does not"
+    if @link.first
+      "Expected link '#{@link.inner_text}' with href '#{@link.first['href']}' to match the list path '#{list_path}', but it does not."
+    else
+      "Expected list path '#{list_path}' to be autolinked in '#{text}', but no link was found."
+    end
   end
 
   failure_message_for_should_not do |text|
-    "expected link #{@link.inner_text} with href #{@link['href']} not to match the list path #{@list_path}, but it does"
+    "Expected link '#{@link.inner_text}' with href '#{@link.first['href']}' not to match the list path '#{list_path}', but it does."
   end
 
   description do
@@ -98,10 +110,14 @@ RSpec::Matchers.define :have_autolinked_hashtag do |hashtag|
   end
 
   failure_message_for_should do |text|
-    if @link
+    if @link.first
       "Expected link text to be [#{hashtag}], but it was [#{@link.inner_text}] in #{text}"
     else
       "Expected hashtag #{hashtag} to be autolinked in '#{text}', but no link was found."
     end
+  end
+
+  failure_message_for_should_not do |text|
+    "Expected link '#{@link.inner_text}' with href '#{@link.first['href']}' not to match the hashtag '#{hashtag}', but it does."
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,24 +51,26 @@ RSpec::Matchers.define :have_autolinked_url do |url, inner_text|
   end
 end
 
-RSpec::Matchers.define :link_to_screen_name do |screen_name|
+RSpec::Matchers.define :link_to_screen_name do |screen_name, inner_text|
+  expected = inner_text ? inner_text : screen_name
+
   match do |text|
     @link = Nokogiri::HTML(text).search("a.username")
     @link &&
-    @link.inner_text == screen_name &&
+    @link.inner_text == expected &&
     "http://twitter.com/#{screen_name}".downcase.should == @link.first['href']
   end
 
   failure_message_for_should do |text|
     if @link.first
-      "Expected link '#{@link.inner_text}' with href '#{@link.first['href']}' to match screen_name '#{screen_name}', but it does not."
+      "Expected link '#{@link.inner_text}' with href '#{@link.first['href']}' to match screen_name '#{expected}', but it does not."
     else
       "Expected screen name '#{screen_name}' to be autolinked in '#{text}', but no link was found."
     end
   end
 
   failure_message_for_should_not do |text|
-    "Expected link '#{@link.inner_text}' with href '#{@link.first['href']}' not to match screen_name '#{screen_name}', but it does."
+    "Expected link '#{@link.inner_text}' with href '#{@link.first['href']}' not to match screen_name '#{expected}', but it does."
   end
 
   description do
@@ -76,24 +78,26 @@ RSpec::Matchers.define :link_to_screen_name do |screen_name|
   end
 end
 
-RSpec::Matchers.define :link_to_list_path do |list_path|
+RSpec::Matchers.define :link_to_list_path do |list_path, inner_text|
+  expected = inner_text ? inner_text : list_path
+
   match do |text|
     @link = Nokogiri::HTML(text).search("a.list-slug")
     @link &&
-    @link.inner_text == list_path &&
+    @link.inner_text == expected &&
     "http://twitter.com/#{list_path}".downcase.should == @link.first['href']
   end
 
   failure_message_for_should do |text|
     if @link.first
-      "Expected link '#{@link.inner_text}' with href '#{@link.first['href']}' to match the list path '#{list_path}', but it does not."
+      "Expected link '#{@link.inner_text}' with href '#{@link.first['href']}' to match the list path '#{expected}', but it does not."
     else
       "Expected list path '#{list_path}' to be autolinked in '#{text}', but no link was found."
     end
   end
 
   failure_message_for_should_not do |text|
-    "Expected link '#{@link.inner_text}' with href '#{@link.first['href']}' not to match the list path '#{list_path}', but it does."
+    "Expected link '#{@link.inner_text}' with href '#{@link.first['href']}' not to match the list path '#{expected}', but it does."
   end
 
   description do


### PR DESCRIPTION
Currently, `auto_link_usernames_or_lists` places the `@` symbol outside of `<a>` tags.

To more closely match twitter's auto-linking behavior for usernames and lists, this patch adds the option `:include_symbol` that allows `@` to be included as part of the link, rather than before it.

This patch also includes some fixes to `spec_helper.rb` to prevent errors on failing specs; if needed that could be submitted as a separate patch.
