### PR TITLE
Extract mentions slightly more strictly

### DIFF
--- a/lib/regex.rb
+++ b/lib/regex.rb
@@ -109,7 +109,7 @@ module Twitter
     REGEXEN[:end_hashtag_match] = /\A(?:[#＃]|:\/\/)/o
 
     REGEXEN[:at_signs] = /[@＠]/
-    REGEXEN[:extract_mentions] = /(^|[^a-zA-Z0-9_])#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})/o
+    REGEXEN[:extract_mentions] = /(^|[^a-zA-Z0-9_!#\$%&*@＠])#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})/o
     REGEXEN[:extract_mentions_or_lists] = /(^|[^a-zA-Z0-9_])#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})(\/[a-zA-Z][a-zA-Z0-9_\-]{0,24})?/o
     REGEXEN[:extract_reply] = /^(?:#{REGEXEN[:spaces]})*#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})/o
     # Used in Extractor and Rewriter for final filtering

--- a/spec/extractor_spec.rb
+++ b/spec/extractor_spec.rb
@@ -41,13 +41,10 @@ describe Twitter::Extractor do
       end
 
       it "should ignore masked bad word" do
-        @extractor.extract_mentioned_screen_names("f!@kn").should == []
-        @extractor.extract_mentioned_screen_names("f@@kn").should == []
-        @extractor.extract_mentioned_screen_names("f#@kn").should == []
-        @extractor.extract_mentioned_screen_names("f$@kn").should == []
-        @extractor.extract_mentioned_screen_names("f%@kn").should == []
-        @extractor.extract_mentioned_screen_names("f&@kn").should == []
-        @extractor.extract_mentioned_screen_names("f*@kn").should == []
+        invalid_chars = ['!', '@', '#', '$', '%', '&', '*']
+        invalid_chars.each do |c|
+          @extractor.extract_mentioned_screen_names("f#{c}@kn").should == []
+        end
       end
     end
 

--- a/spec/extractor_spec.rb
+++ b/spec/extractor_spec.rb
@@ -40,7 +40,7 @@ describe Twitter::Extractor do
         @extractor.extract_mentioned_screen_names("の@aliceに到着を待っている").should == ["alice"]
       end
 
-      it "should ignore masked bad word" do
+      it "should ignore mentions preceded by !, @, #, $, %, & or *" do
         invalid_chars = ['!', '@', '#', '$', '%', '&', '*']
         invalid_chars.each do |c|
           @extractor.extract_mentioned_screen_names("f#{c}@kn").should == []

--- a/spec/extractor_spec.rb
+++ b/spec/extractor_spec.rb
@@ -39,6 +39,16 @@ describe Twitter::Extractor do
       it "should be linked in Japanese text" do
         @extractor.extract_mentioned_screen_names("の@aliceに到着を待っている").should == ["alice"]
       end
+
+      it "should ignore masked bad word" do
+        @extractor.extract_mentioned_screen_names("f!@kn").should == []
+        @extractor.extract_mentioned_screen_names("f@@kn").should == []
+        @extractor.extract_mentioned_screen_names("f#@kn").should == []
+        @extractor.extract_mentioned_screen_names("f$@kn").should == []
+        @extractor.extract_mentioned_screen_names("f%@kn").should == []
+        @extractor.extract_mentioned_screen_names("f&@kn").should == []
+        @extractor.extract_mentioned_screen_names("f*@kn").should == []
+      end
     end
 
     it "should accept a block arugment and call it in order" do

--- a/twitter-text.gemspec
+++ b/twitter-text.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "twitter-text"
-  s.version = "1.4.15"
+  s.version = "1.4.16"
   s.authors = ["Matt Sanford", "Patrick Ewing", "Ben Cherry", "Britt Selvitelle",
                "Raffi Krikorian", "J.P. Cummins", "Yoshimasa Niwa", "Keita Fujii"]
   s.email = ["matt@twitter.com", "patrick.henry.ewing@gmail.com", "bcherry@gmail.com", "bs@brittspace.com",

--- a/twitter-text.gemspec
+++ b/twitter-text.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "twitter-text"
-  s.version = "1.4.16"
+  s.version = "1.4.15"
   s.authors = ["Matt Sanford", "Patrick Ewing", "Ben Cherry", "Britt Selvitelle",
                "Raffi Krikorian", "J.P. Cummins", "Yoshimasa Niwa", "Keita Fujii"]
   s.email = ["matt@twitter.com", "patrick.henry.ewing@gmail.com", "bcherry@gmail.com", "bs@brittspace.com",


### PR DESCRIPTION
I made extraction of mentions slightly more strict.
Now it does not extract mentions precedented by !, @, #, $, %, & and _.
This avoids extracting unintended mentions like "f_@kn", which, in turn, reduces spams in users mention section.
