### PR TITLE
Refactor twitter-text to allow punctuation characters before URL.

### DIFF
--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -62,12 +62,7 @@ module Twitter
       end
       
       html_attrs = nil
-      begin_index = 0
-      result = ""
-      chars = text.chars.to_a
-      
-      entities.each do |entity|
-        result << chars[begin_index...entity[:indices].first].to_s
+      Twitter::Rewriter.rewrite_entities(text, entities) do |entity, chars|
         if entity[:url]
           url = entity[:url]
           href = if options[:link_url_block]
@@ -82,7 +77,7 @@ module Twitter
           end
   
           html_attrs = html_attrs_for_options(options) unless html_attrs
-          result << %(<a href="#{href}"#{html_attrs}>#{html_escape(display_url)}</a>)
+          %(<a href="#{href}"#{html_attrs}>#{html_escape(display_url)}</a>)
         elsif entity[:hashtag]
           hashtag = entity[:hashtag]
           hash = chars[entity[:indices].first]
@@ -92,7 +87,7 @@ module Twitter
           else
             "#{options[:hashtag_url_base]}#{html_escape(hashtag)}"
           end
-          result << %(<a href="#{href}" title="##{html_escape(hashtag)}" #{target_tag(options)}class="#{options[:url_class]} #{options[:hashtag_class]}"#{extra_html}>#{hash}#{html_escape(hashtag)}</a>)
+          %(<a href="#{href}" title="##{html_escape(hashtag)}" #{target_tag(options)}class="#{options[:url_class]} #{options[:hashtag_class]}"#{extra_html}>#{hash}#{html_escape(hashtag)}</a>)
         elsif entity[:screen_name]
           name = "#{entity[:screen_name]}#{entity[:list_slug]}"
           chunk = block_given? ? yield(name) : name
@@ -104,21 +99,17 @@ module Twitter
             else
               "#{html_escape(options[:list_url_base])}#{html_escape(name.downcase)}"
             end
-            result << %(#{at}<a class="#{options[:url_class]} #{options[:list_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
+            %(#{at}<a class="#{options[:url_class]} #{options[:list_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
           else
             href = if options[:username_url_block]
               options[:username_url_block].call(chunk)
             else
               "#{html_escape(options[:username_url_base])}#{html_escape(chunk)}"
             end
-            result << %(#{at}<a class="#{options[:url_class]} #{options[:username_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
+            %(#{at}<a class="#{options[:url_class]} #{options[:username_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
           end
         end
-        begin_index = entity[:indices].last
       end
-      result << chars[begin_index..-1].to_s
-      
-      result
     end
 
     # Add <tt><a></a></tt> tags around the usernames, lists, hashtags and URLs in the provided <tt>text</tt>. The

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -38,7 +38,7 @@ module Twitter
 
     def auto_link_entities(text, entities, options)
       return text if entities.empty?
-      
+
       options = options.dup
       options[:class] = options[:url_class]
       options[:rel] = "nofollow" unless options[:suppress_no_follow]
@@ -51,7 +51,7 @@ module Twitter
       options[:hashtag_url_base] ||= "http://twitter.com/#!/search?q=%23"
       options[:target] ||= DEFAULT_TARGET
       extra_html = HTML_ATTR_NO_FOLLOW unless options[:suppress_no_follow]
-      
+
       url_entities = {}
       if options[:url_entities]
         options[:url_entities].each do |entity|
@@ -60,7 +60,7 @@ module Twitter
         end
         options.delete(:url_entities)
       end
-      
+
       html_attrs = nil
       Twitter::Rewriter.rewrite_entities(text, entities) do |entity, chars|
         if entity[:url]
@@ -70,12 +70,12 @@ module Twitter
           else
             html_escape(url)
           end
-  
+
           display_url = url
           if url_entities[url] && url_entities[url][:display_url]
             display_url = url_entities[url][:display_url]
           end
-  
+
           html_attrs = html_attrs_for_options(options) unless html_attrs
           %(<a href="#{href}"#{html_attrs}>#{html_escape(display_url)}</a>)
         elsif entity[:hashtag]
@@ -131,7 +131,7 @@ module Twitter
     def auto_link(text, options = {})
       auto_link_entities(text, Extractor.extract_entities_with_indices(text, {:extract_url_without_protocol => false}), options)
     end
-    
+
     # Add <tt><a></a></tt> tags around the usernames and lists in the provided <tt>text</tt>. The
     # <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt>
     # hash:

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -46,15 +46,23 @@ module Twitter
   # of usernames, lists, URLs and hashtags.
   module Extractor extend self
 
+    # Extracts all usernames, lists, hashtags and URLs  in the Tweet <tt>text</tt>
+    # along with the indices for where the entity ocurred
+    # If the <tt>text</tt> is <tt>nil</tt> or contains no entity an empty array
+    # will be returned.
+    #
+    # If a block is given then it will be called for each entity.
     def extract_entities_with_indices(text, options = {})
       # extract all entities
-      entities = extract_urls_with_indices(text, options) + extract_hashtags_with_indices(text) + extract_mentions_or_lists_with_indices(text)
-      
+      entities = extract_urls_with_indices(text, options) +
+                 extract_hashtags_with_indices(text) +
+                 extract_mentions_or_lists_with_indices(text)
+
       return [] if entities.empty?
 
       # sort by start index
       entities.sort! {|a,b| a[:indices].first <=> b[:indices].first}
-      
+
       # remove duplicates
       prev = nil
       entities.each do |entity|
@@ -64,10 +72,11 @@ module Twitter
           prev = entity
         end
       end
-      
+
+      entities.each{|entity| yield entity} if block_given?
       entities
     end
-    
+
     # Extracts a list of all usernames mentioned in the Tweet <tt>text</tt>. If the
     # <tt>text</tt> is <tt>nil</tt> or contains no username mentions an empty array
     # will be returned.

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -48,24 +48,22 @@ module Twitter
 
     def extract_entities_with_indices(text, options = {})
       # extract all entities
-      entities = extract_urls_with_indices(text, options)
-      entities += extract_hashtags_with_indices(text)
-      entities += extract_mentions_or_lists_with_indices(text)
+      entities = extract_urls_with_indices(text, options) + extract_hashtags_with_indices(text) + extract_mentions_or_lists_with_indices(text)
       
+      return [] if entities.empty?
+
       # sort by start index
       entities.sort! {|a,b| a[:indices].first <=> b[:indices].first}
       
-      return [] if entities.empty?
-      
       # remove duplicates
       prev = nil
-      entities.each{|entity|
+      entities.each do |entity|
         if prev != nil && prev[:indices].last > entity[:indices].first
           entities.delete entity
         else
           prev = entity
         end
-      }
+      end
       
       entities
     end
@@ -117,7 +115,7 @@ module Twitter
     # index, and the end index in the <tt>text</tt>. The list_slug will be an empty stirng
     # if this is a username mention.
     def extract_mentions_or_lists_with_indices(text) # :yields: username, list_slug, start, end
-      return [] unless text
+      return [] unless text && text.index(/[@＠]/)
 
       possible_entries = []
       text.to_s.scan(Twitter::Regex[:valid_mention_or_list]) do |before, at, screen_name, list_slug|
@@ -175,7 +173,7 @@ module Twitter
     #
     # If a block is given then it will be called for each URL.
     def extract_urls_with_indices(text, options = {}) # :yields: url, start, end
-      return [] unless text
+      return [] unless text && text.index(".")
       urls = []
       position = 0
       extract_url_without_protocol = options[:extract_url_without_protocol]
@@ -248,7 +246,7 @@ module Twitter
     #
     # If a block is given then it will be called for each hashtag.
     def extract_hashtags_with_indices(text) # :yields: hashtag_text, start, end
-      return [] unless text
+      return [] unless text && text.index(/[#＃]/)
 
       tags = []
       text.scan(Twitter::Regex[:valid_hashtag]) do |before, hash, hash_text|

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -176,7 +176,6 @@ module Twitter
       return [] unless text && (options[:extract_url_without_protocol] ? text.index(".") : text.index(":"))
       urls = []
       position = 0
-      extract_url_without_protocol = options[:extract_url_without_protocol]
 
       text.to_s.scan(Twitter::Regex[:valid_url]) do |all, before, url, protocol, domain, port, path, query|
         valid_url_match_data = $~
@@ -187,7 +186,7 @@ module Twitter
         # If protocol is missing and domain contains non-ASCII characters,
         # extract ASCII-only domains.
         if !protocol
-          next if !extract_url_without_protocol || before =~ Twitter::Regex[:invalid_url_without_protocol_preceding_chars]
+          next if !options[:extract_url_without_protocol] || before =~ Twitter::Regex[:invalid_url_without_protocol_preceding_chars]
           last_url = nil
           last_url_invalid_match = nil
           domain.scan(Twitter::Regex[:valid_ascii_domain]) do |ascii_domain|

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -172,12 +172,11 @@ module Twitter
     # URLs an empty array will be returned.
     #
     # If a block is given then it will be called for each URL.
-    def extract_urls_with_indices(text, options = {}) # :yields: url, start, end
-      return [] unless text && text.index(".")
+    def extract_urls_with_indices(text, options = {:extract_url_without_protocol => true}) # :yields: url, start, end
+      return [] unless text && (options[:extract_url_without_protocol] ? text.index(".") : text.index(":"))
       urls = []
       position = 0
       extract_url_without_protocol = options[:extract_url_without_protocol]
-      extract_url_without_protocol = true if extract_url_without_protocol == nil
 
       text.to_s.scan(Twitter::Regex[:valid_url]) do |all, before, url, protocol, domain, port, path, query|
         valid_url_match_data = $~
@@ -188,7 +187,7 @@ module Twitter
         # If protocol is missing and domain contains non-ASCII characters,
         # extract ASCII-only domains.
         if !protocol
-          next if !extract_url_without_protocol
+          next if !extract_url_without_protocol || before =~ Twitter::Regex[:invalid_url_without_protocol_preceding_chars]
           last_url = nil
           last_url_invalid_match = nil
           domain.scan(Twitter::Regex[:valid_ascii_domain]) do |ascii_domain|

--- a/lib/regex.rb
+++ b/lib/regex.rb
@@ -121,7 +121,8 @@ module Twitter
     REGEXEN[:end_mention_match] = /\A(?:#{REGEXEN[:at_signs]}|#{REGEXEN[:latin_accents]}|:\/\/)/o
 
     # URL related hash regex collection
-    REGEXEN[:valid_url_preceding_chars] = /(?:[^-\/"'!=A-Z0-9_@＠\$#＃\.#{INVALID_CHARACTERS.join('')}]|^)/io
+    REGEXEN[:valid_url_preceding_chars] = /(?:[^A-Z0-9@＠$#＃#{INVALID_CHARACTERS.join('')}]|^)/io
+    REGEXEN[:invalid_url_without_protocol_preceding_chars] = /[-_.\/]$/
     DOMAIN_VALID_CHARS = "[^[:punct:][:space:][:blank:][:cntrl:]#{INVALID_CHARACTERS.join('')}#{UNICODE_SPACES.join('')}]"
     REGEXEN[:valid_subdomain] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[_-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io
     REGEXEN[:valid_domain_name] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io

--- a/lib/regex.rb
+++ b/lib/regex.rb
@@ -104,23 +104,24 @@ module Twitter
 
     HASHTAG = /(#{HASHTAG_BOUNDARY})(#|＃)(#{HASHTAG_ALPHANUMERIC}*#{HASHTAG_ALPHA}#{HASHTAG_ALPHANUMERIC}*)/io
 
-    REGEXEN[:auto_link_hashtags] = /#{HASHTAG}/io
+    REGEXEN[:valid_hashtag] = /#{HASHTAG}/io
     # Used in Extractor and Rewriter for final filtering
     REGEXEN[:end_hashtag_match] = /\A(?:[#＃]|:\/\/)/o
 
+    REGEXEN[:valid_mention_preceding_chars] = /(?:[^a-zA-Z0-9_]|^|RT:?)/o
     REGEXEN[:at_signs] = /[@＠]/
-    REGEXEN[:extract_mentions] = /(^|[^a-zA-Z0-9_])#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})/o
-    REGEXEN[:extract_mentions_or_lists] = /(^|[^a-zA-Z0-9_])#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})(\/[a-zA-Z][a-zA-Z0-9_\-]{0,24})?/o
-    REGEXEN[:extract_reply] = /^(?:#{REGEXEN[:spaces]})*#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})/o
+    REGEXEN[:valid_mention_or_list] = /
+      (#{REGEXEN[:valid_mention_preceding_chars]})  # $1: Preceeding character
+      (#{REGEXEN[:at_signs]})                       # $2: At mark
+      ([a-zA-Z0-9_]{1,20})                          # $3: Screen name
+      (\/[a-zA-Z][a-zA-Z0-9_\-]{0,24})?             # $4: List (optional)
+    /ox
+    REGEXEN[:valid_reply] = /^(?:#{REGEXEN[:spaces]})*#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})/o
     # Used in Extractor and Rewriter for final filtering
-    REGEXEN[:end_screen_name_match] = /\A(?:#{REGEXEN[:at_signs]}|#{REGEXEN[:latin_accents]}|:\/\/)/o
-
-    REGEXEN[:auto_link_usernames_or_lists] = /([^a-zA-Z0-9_]|^|RT:?)([@＠]+)([a-zA-Z0-9_]{1,20})(\/[a-zA-Z][a-zA-Z0-9_\-]{0,24})?/o
-    REGEXEN[:auto_link_emoticon] = /(8\-\#|8\-E|\+\-\(|\`\@|\`O|\&lt;\|:~\(|\}:o\{|:\-\[|\&gt;o\&lt;|X\-\/|\[:-\]\-I\-|\/\/\/\/Ö\\\\\\\\|\(\|:\|\/\)|∑:\*\)|\( \| \))/
+    REGEXEN[:end_mention_match] = /\A(?:#{REGEXEN[:at_signs]}|#{REGEXEN[:latin_accents]}|:\/\/)/o
 
     # URL related hash regex collection
-    REGEXEN[:valid_preceding_chars] = /(?:[^-\/"'!=A-Z0-9_@＠\$#＃\.#{INVALID_CHARACTERS.join('')}]|^)/io
-
+    REGEXEN[:valid_url_preceding_chars] = /(?:[^-\/"'!=A-Z0-9_@＠\$#＃\.#{INVALID_CHARACTERS.join('')}]|^)/io
     DOMAIN_VALID_CHARS = "[^[:punct:][:space:][:blank:][:cntrl:]#{INVALID_CHARACTERS.join('')}#{UNICODE_SPACES.join('')}]"
     REGEXEN[:valid_subdomain] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[_-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io
     REGEXEN[:valid_domain_name] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io
@@ -179,7 +180,7 @@ module Twitter
     REGEXEN[:valid_url_query_ending_chars] = /[a-z0-9_&=#\/]/i
     REGEXEN[:valid_url] = %r{
       (                                                                                     #   $1 total match
-        (#{REGEXEN[:valid_preceding_chars]})                                                #   $2 Preceeding chracter
+        (#{REGEXEN[:valid_url_preceding_chars]})                                            #   $2 Preceeding chracter
         (                                                                                   #   $3 URL
           (https?:\/\/)?                                                                    #   $4 Protocol (optional)
           (#{REGEXEN[:valid_domain]})                                                       #   $5 Domain(s)

--- a/lib/rewriter.rb
+++ b/lib/rewriter.rb
@@ -19,13 +19,13 @@ module Twitter
         if index % 4 != 0
           new_text << chunk
         else
-          new_text << chunk.gsub(Twitter::Regex[:auto_link_usernames_or_lists]) do
+          new_text << chunk.gsub(Twitter::Regex[:valid_mention_or_list]) do
             before, at, user, slash_listname, after = $1, $2, $3, $4, $'
             if slash_listname
               # the link is a list
               "#{before}#{yield(at, user, slash_listname)}"
             else
-              if after =~ Twitter::Regex[:end_screen_name_match]
+              if after =~ Twitter::Regex[:end_mention_match]
                 # Followed by something that means we don't autolink
                 "#{before}#{at}#{user}#{slash_listname}"
               else
@@ -41,7 +41,7 @@ module Twitter
     end
 
     def rewrite_hashtags(text)
-      text.to_s.gsub(Twitter::Regex[:auto_link_hashtags]) do
+      text.to_s.gsub(Twitter::Regex[:valid_hashtag]) do
         before, hash, hashtag, after = $1, $2, $3, $'
         if after =~ Twitter::Regex[:end_hashtag_match]
           "#{before}#{hash}#{hashtag}"

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -52,7 +52,7 @@ module Twitter
       extracted.size == 1 && extracted.first == username[1..-1]
     end
 
-    VALID_LIST_RE = /\A#{Twitter::Regex[:auto_link_usernames_or_lists]}\z/o
+    VALID_LIST_RE = /\A#{Twitter::Regex[:valid_mention_or_list]}\z/o
     def valid_list?(username_list)
       match = username_list.match(VALID_LIST_RE)
       # Must have matched and had nothing before or after

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -541,6 +541,12 @@ describe Twitter::Autolink do
         auto_linked.should_not include('hashtag_classname')
       end
 
+      it "should autolink url/hashtag/mention in text with Unicode supplementary characters" do
+        auto_linked = @linker.auto_link("#{[0x10400].pack('U')} #hashtag #{[0x10400].pack('U')} @mention #{[0x10400].pack('U')} http://twitter.com/")
+        auto_linked.should have_autolinked_hashtag('#hashtag')
+        auto_linked.should link_to_screen_name('mention')
+        auto_linked.should have_autolinked_url('http://twitter.com/')
+      end
     end
 
   end

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -424,10 +424,10 @@ describe Twitter::Autolink do
       end
 
       context "with a URL preceded in forbidden characters" do
-        it "should not be linked" do
+        it "should be linked" do
           matcher = TestAutolink.new
           %w| \ ' / ! = |.each do |char|
-            matcher.auto_link("#{char}#{url}").should_not have_autolinked_url(url)
+            matcher.auto_link("#{char}#{url}").should have_autolinked_url(url)
           end
         end
       end

--- a/spec/extractor_spec.rb
+++ b/spec/extractor_spec.rb
@@ -100,6 +100,10 @@ describe Twitter::Extractor do
       end
       needed.should == []
     end
+
+    it "should extract screen name in text with supplementary character" do
+      @extractor.extract_mentioned_screen_names_with_indices("#{[0x10400].pack('U')} @alice").should == [{:screen_name => "alice", :indices => [2, 8]}]
+    end
   end
 
   describe "replies" do
@@ -213,6 +217,10 @@ describe Twitter::Extractor do
           extracted_url[:indices].first.should == 11
           extracted_url[:indices].last.should == 11 + url.chars.to_a.size
         end
+      end
+
+      it "should extract URL in text with supplementary character" do
+        @extractor.extract_urls_with_indices("#{[0x10400].pack('U')} http://twitter.com").should == [{:url => "http://twitter.com", :indices => [2, 20]}]
       end
     end
 
@@ -344,6 +352,10 @@ describe Twitter::Extractor do
 
     it "should not extract numeric hashtags" do
       not_match_hashtag_in_text("#1234")
+    end
+
+    it "should extract hashtag in text with supplementary character" do
+      match_hashtag_in_text("hashtag", "#{[0x10400].pack('U')} #hashtag", 2)
     end
   end
 end

--- a/spec/rewriter_spec.rb
+++ b/spec/rewriter_spec.rb
@@ -469,11 +469,11 @@ describe Twitter::Rewriter do
     end
 
     context "with a URL preceded in forbidden characters" do
-      it "should not be rewritten" do
+      it "should be rewritten" do
         %w| \ ' / ! = |.each do |char|
           Twitter::Rewriter.rewrite_urls("#{char}#{url}") do |url|
             "[rewritten]" # should not be called here.
-          end.should == "#{char}#{url}"
+          end.should == "#{char}[rewritten]"
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ end
 
 RSpec::Matchers.define :match_autolink_expression do
   match do |string|
-    Twitter::Regex[:valid_url].match(string)
+    !Twitter::Extractor.extract_urls(string).empty?
   end
 end
 


### PR DESCRIPTION
Currently twitter-text doesn't allow punctuation characters like " or . before URL. But if we change Regex to allow those characters before URL Autolink.auto_link() will break because it'll auto-link the URLs added by auto_link_hashtags/usernames_and_lists(). To solve it, this modifies Autolink to use Extractor to extract all entities first, then use them to auto-link the text.

This also includes performance improvement (which doubles the speed of Autolink/Extractor on my laptop) as well as other minor refactoring.

Here is the list of changes in this branch:
- Add new method Extractor.extract_entities_with_indices(), which extracts all entities (hashtag, mention, URLs) from a given text.
- Modify Rewriter.rewrite*() to use Extractor to extract entities instead of applying Regex.
- Allow punctuation characters like '"', '.' or '!' before URL.
- Consolidate AUTO_LINK_USERNAMES\* and EXTRACT_MENTIONS into VALID_MENTION_OR_LIST
- Improve performance of Extractor.extract*() by scanning the text before applying complex regex patterns.
- Add an option in Extractor.extract_urls*() to enable/disable extracting URLs without protocol.
