### PR TITLE
added encoding UTF-8

### DIFF
--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require 'set'
 
 module Twitter


### PR DESCRIPTION
without this i run into:

/Users/paul/.rvm/gems/ruby-1.9.3-p125@thorax/bundler/gems/twitter-text-rb-d91a9fff88b0/lib/twitter-text.rb:16:in `require': /Users/paul/.rvm/gems/ruby-1.9.3-p125@thorax/bundler/gems/twitter-text-rb-d91a9fff88b0/lib/autolink.rb:194: invalid multibyte char (US-ASCII) (SyntaxError)
/Users/paul/.rvm/gems/ruby-1.9.3-p125@thorax/bundler/gems/twitter-text-rb-d91a9fff88b0/lib/autolink.rb:194: invalid multibyte char (US-ASCII)
/Users/paul/.rvm/gems/ruby-1.9.3-p125@thorax/bundler/gems/twitter-text-rb-d91a9fff88b0/lib/autolink.rb:194: syntax error, unexpected $end, expecting ')'
          display_url_sans_ellipses = display_url.sub("…", "")
