### PR TITLE
Refactoring and allow punct before url

### DIFF
--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -161,8 +161,6 @@ module Twitter
     end
 
     def link_to_url(entity, chars, options = {})
-      url_entities = options[:url_entities] || {}
-
       url = entity[:url]
 
       href = if options[:link_url_block]
@@ -171,66 +169,76 @@ module Twitter
         html_escape(url)
       end
 
-      display_url = url
-      link_text = html_escape(display_url)
-      if url_entities[url] && url_entities[url]["display_url"]
-        display_url = url_entities[url]["display_url"]
-        expanded_url = url_entities[url]["expanded_url"]
-        if !options[:title]
-          options[:title] = expanded_url
-        end
-
-        # Goal: If a user copies and pastes a tweet containing t.co'ed link, the resulting paste
-        # should contain the full original URL (expanded_url), not the display URL.
-        #
-        # Method: Whenever possible, we actually emit HTML that contains expanded_url, and use
-        # font-size:0 to hide those parts that should not be displayed (because they are not part of display_url).
-        # Elements with font-size:0 get copied even though they are not visible.
-        # Note that display:none doesn't work here. Elements with display:none don't get copied.
-        #
-        # Additionally, we want to *display* ellipses, but we don't want them copied.  To make this happen we
-        # wrap the ellipses in a tco-ellipsis class and provide an onCopy handler that sets display:none on
-        # everything with the tco-ellipsis class.
-        #
-        # Exception: pic.twitter.com images, for which expandedUrl = "https://twitter.com/#!/username/status/1234/photo/1
-        # For those URLs, display_url is not a substring of expanded_url, so we don't do anything special to render the elided parts.
-        # For a pic.twitter.com URL, the only elided part will be the "https://", so this is fine.
-        display_url_sans_ellipses = display_url.sub("…", "")
-        if expanded_url.include?(display_url_sans_ellipses)
-          display_url_index = expanded_url.index(display_url_sans_ellipses)
-          before_display_url = expanded_url.slice(0, display_url_index)
-          # Portion of expanded_url that comes after display_url
-          after_display_url = expanded_url.slice(display_url_index + display_url_sans_ellipses.length, 999999)
-          preceding_ellipsis = display_url.match(/^…/) ? "…" : ""
-          following_ellipsis = display_url.match(/…$/) ? "…" : ""
-          # As an example: The user tweets "hi http://longdomainname.com/foo"
-          # This gets shortened to "hi http://t.co/xyzabc", with display_url = "…nname.com/foo"
-          # This will get rendered as:
-          # <span class='tco-ellipsis'> <!-- This stuff should get displayed but not copied -->
-          #   …
-          #   <!-- There's a chance the onCopy event handler might not fire. In case that happens,
-          #        we include an &nbsp; here so that the … doesn't bump up against the URL and ruin it.
-          #        The &nbsp; is inside the tco-ellipsis span so that when the onCopy handler *does*
-          #        fire, it doesn't get copied.  Otherwise the copied text would have two spaces in a row,
-          #        e.g. "hi  http://longdomainname.com/foo".
-          #   <span style='font-size:0'>&nbsp;</span>
-          # </span>
-          # <span style='font-size:0'>  <!-- This stuff should get copied but not displayed -->
-          #   http://longdomai
-          # </span>
-          # <span class='js-display-url'> <!-- This stuff should get displayed *and* copied -->
-          #   nname.com/foo
-          # </span>
-          # <span class='tco-ellipsis'> <!-- This stuff should get displayed but not copied -->
-          #   <span style='font-size:0'>&nbsp;</span>
-          #   …
-          # </span>
-          invisible = "style='font-size:0; line-height:0'"
-          link_text = "<span class='tco-ellipsis'>#{preceding_ellipsis}<span #{invisible}>&nbsp;</span></span><span #{invisible}>#{html_escape before_display_url}</span><span class='js-display-url'>#{html_escape display_url_sans_ellipses}</span><span #{invisible}>#{after_display_url}</span><span class='tco-ellipsis'><span #{invisible}>&nbsp;</span>#{following_ellipsis}</span>"
-        end
+      link_text = if options[:url_entities] &&
+                     (url_entity = options[:url_entities][url]) &&
+                     url_entity["display_url"]
+        options[:html_attrs][:title] = url_entity["expanded_url"]
+        link_text_with_entity(url_entity)
+      else
+        html_escape(url)
       end
 
       link_to(link_text, href, options[:html_attrs])
+    end
+
+    INVISIBLE_TAG_ATTRS = "style='font-size:0; line-height:0'".freeze
+
+    def link_text_with_entity(url_entity)
+      display_url  = url_entity["display_url"]
+      expanded_url = url_entity["expanded_url"]
+
+      # Goal: If a user copies and pastes a tweet containing t.co'ed link, the resulting paste
+      # should contain the full original URL (expanded_url), not the display URL.
+      #
+      # Method: Whenever possible, we actually emit HTML that contains expanded_url, and use
+      # font-size:0 to hide those parts that should not be displayed (because they are not part of display_url).
+      # Elements with font-size:0 get copied even though they are not visible.
+      # Note that display:none doesn't work here. Elements with display:none don't get copied.
+      #
+      # Additionally, we want to *display* ellipses, but we don't want them copied.  To make this happen we
+      # wrap the ellipses in a tco-ellipsis class and provide an onCopy handler that sets display:none on
+      # everything with the tco-ellipsis class.
+      #
+      # Exception: pic.twitter.com images, for which expandedUrl = "https://twitter.com/#!/username/status/1234/photo/1
+      # For those URLs, display_url is not a substring of expanded_url, so we don't do anything special to render the elided parts.
+      # For a pic.twitter.com URL, the only elided part will be the "https://", so this is fine.
+      display_url_sans_ellipses = display_url.gsub("…", "")
+
+      if expanded_url.include?(display_url_sans_ellipses)
+        before_display_url, after_display_url = expanded_url.split(display_url_sans_ellipses, 2)
+        preceding_ellipsis = /\A…/.match(display_url).to_s
+        following_ellipsis = /…\z/.match(display_url).to_s
+
+        # As an example: The user tweets "hi http://longdomainname.com/foo"
+        # This gets shortened to "hi http://t.co/xyzabc", with display_url = "…nname.com/foo"
+        # This will get rendered as:
+        # <span class='tco-ellipsis'> <!-- This stuff should get displayed but not copied -->
+        #   …
+        #   <!-- There's a chance the onCopy event handler might not fire. In case that happens,
+        #        we include an &nbsp; here so that the … doesn't bump up against the URL and ruin it.
+        #        The &nbsp; is inside the tco-ellipsis span so that when the onCopy handler *does*
+        #        fire, it doesn't get copied.  Otherwise the copied text would have two spaces in a row,
+        #        e.g. "hi  http://longdomainname.com/foo".
+        #   <span style='font-size:0'>&nbsp;</span>
+        # </span>
+        # <span style='font-size:0'>  <!-- This stuff should get copied but not displayed -->
+        #   http://longdomai
+        # </span>
+        # <span class='js-display-url'> <!-- This stuff should get displayed *and* copied -->
+        #   nname.com/foo
+        # </span>
+        # <span class='tco-ellipsis'> <!-- This stuff should get displayed but not copied -->
+        #   <span style='font-size:0'>&nbsp;</span>
+        #   …
+        # </span>
+        %(<span class="tco-ellipsis">#{preceding_ellipsis}<span #{INVISIBLE_TAG_ATTRS}>&nbsp;</span></span>) <<
+        %(<span #{INVISIBLE_TAG_ATTRS}>#{html_escape(before_display_url)}</span>) <<
+        %(<span class="js-display-url">#{html_escape(display_url_sans_ellipses)}</span>) <<
+        %(<span #{INVISIBLE_TAG_ATTRS}>#{html_escape(after_display_url)}</span>) <<
+        %(<span class="tco-ellipsis"><span #{INVISIBLE_TAG_ATTRS}>&nbsp;</span>#{following_ellipsis}</span>)
+      else
+        html_escape(display_url)
+      end
     end
 
     def link_to_hashtag(entity, chars, options = {})

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -6,6 +6,52 @@ module Twitter
   # A module for including Tweet auto-linking in a class. The primary use of this is for helpers/views so they can auto-link
   # usernames, lists, hashtags and URLs.
   module Autolink extend self
+    # Default CSS class for auto-linked URLs
+    DEFAULT_URL_CLASS = "tweet-url".freeze
+    # Default CSS class for auto-linked lists (along with the url class)
+    DEFAULT_LIST_CLASS = "list-slug".freeze
+    # Default CSS class for auto-linked usernames (along with the url class)
+    DEFAULT_USERNAME_CLASS = "username".freeze
+    # Default CSS class for auto-linked hashtags (along with the url class)
+    DEFAULT_HASHTAG_CLASS = "hashtag".freeze
+
+    # Default URL base for auto-linked usernames
+    DEFAULT_USERNAME_URL_BASE = "https://twitter.com/".freeze
+    # Default URL base for auto-linked lists
+    DEFAULT_LIST_URL_BASE = "https://twitter.com/".freeze
+    # Default URL base for auto-linked hashtags
+    DEFAULT_HASHTAG_URL_BASE = "https://twitter.com/#!/search?q=%23".freeze
+
+    DEFAULT_OPTIONS = {
+      :url_class      => DEFAULT_URL_CLASS,
+      :list_class     => DEFAULT_LIST_CLASS,
+      :username_class => DEFAULT_USERNAME_CLASS,
+      :hashtag_class  => DEFAULT_HASHTAG_CLASS,
+
+      :username_url_base => DEFAULT_USERNAME_URL_BASE,
+      :list_url_base     => DEFAULT_LIST_URL_BASE,
+      :hashtag_url_base  => DEFAULT_HASHTAG_URL_BASE
+    }.freeze
+
+    def auto_link_entities(text, entities, options = {}, &block)
+      return text if entities.empty?
+
+      # NOTE deprecate these attributes not options keys in options hash, then use html_attrs
+      options = DEFAULT_OPTIONS.merge(options)
+      options[:html_attrs] = extract_html_attrs_from_options!(options)
+      options[:html_attrs][:rel] ||= "nofollow" unless options[:suppress_no_follow]
+
+      Twitter::Rewriter.rewrite_entities(text, entities) do |entity, chars|
+        if entity[:url]
+          link_to_url(entity, chars, options, &block)
+        elsif entity[:hashtag]
+          link_to_hashtag(entity, chars, options, &block)
+        elsif entity[:screen_name]
+          link_to_screen_name(entity, chars, options, &block)
+        end
+      end
+    end
+
     # Add <tt><a></a></tt> tags around the usernames, lists, hashtags and URLs in the provided <tt>text</tt>.
     # The <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt> hash:
     # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
@@ -78,43 +124,6 @@ module Twitter
     deprecate :auto_link_urls_custom, :auto_link_urls
 
     private
-
-    DEFAULT_OPTIONS = {
-      # Default CSS class for auto-linked URLs
-      :url_class      => "tweet-url",
-      # Default CSS class for auto-linked lists (along with the url class)
-      :list_class     => "list-slug",
-      # Default CSS class for auto-linked usernames (along with the url class)
-      :username_class => "username",
-      # Default CSS class for auto-linked hashtags (along with the url class)
-      :hashtag_class  => "hashtag",
-
-      # Default URL base for auto-linked usernames
-      :username_url_base => "https://twitter.com/",
-      # Default URL base for auto-linked lists
-      :list_url_base     => "https://twitter.com/",
-      # Default URL base for auto-linked hashtags
-      :hashtag_url_base  => "https://twitter.com/#!/search?q=%23",
-    }.freeze
-
-    def auto_link_entities(text, entities, options = {}, &block)
-      return text if entities.empty?
-
-      # NOTE deprecate these attributes not options keys in options hash, then use html_attrs
-      options = DEFAULT_OPTIONS.merge(options)
-      options[:html_attrs] = extract_html_attrs_from_options!(options)
-      options[:html_attrs][:rel] ||= "nofollow" unless options[:suppress_no_follow]
-
-      Twitter::Rewriter.rewrite_entities(text, entities) do |entity, chars|
-        if entity[:url]
-          link_to_url(entity, chars, options, &block)
-        elsif entity[:hashtag]
-          link_to_hashtag(entity, chars, options, &block)
-        elsif entity[:screen_name]
-          link_to_screen_name(entity, chars, options, &block)
-        end
-      end
-    end
 
     HTML_ENTITIES = {
       '&' => '&amp;',

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -251,7 +251,9 @@ module Twitter
 
       html_attrs = {
         :class => "#{options[:url_class]} #{options[:hashtag_class]}",
-        :title => text
+        # FIXME As our conformance test, hash in title should be half-width,
+        # this should be bug of conformance data.
+        :title => "##{hashtag}"
       }.merge(options[:html_attrs])
 
       link_to(text, href, html_attrs)

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -165,8 +165,8 @@ module Twitter
     # <tt>:suppress_lists</tt>::    disable auto-linking to lists
     # <tt>:suppress_no_follow</tt>::   Do not add <tt>rel="nofollow"</tt> to auto-linked items
     # <tt>:target</tt>::   add <tt>target="window_name"</tt> to auto-linked items
-    def auto_link(text, options = {})
-      auto_link_entities(text, Extractor.extract_entities_with_indices(text, {:extract_url_without_protocol => false}), options)
+    def auto_link(text, options = {}, &block)
+      auto_link_entities(text, Extractor.extract_entities_with_indices(text, :extract_url_without_protocol => false), options, &block)
     end
 
     # Add <tt><a></a></tt> tags around the usernames and lists in the provided <tt>text</tt>. The
@@ -182,14 +182,8 @@ module Twitter
     # <tt>:suppress_lists</tt>::    disable auto-linking to lists
     # <tt>:suppress_no_follow</tt>::   Do not add <tt>rel="nofollow"</tt> to auto-linked items
     # <tt>:target</tt>::   add <tt>target="window_name"</tt> to auto-linked items
-    def auto_link_usernames_or_lists(text, options = {}) # :yields: list_or_username
-      if block_given?
-        auto_link_entities(text, Extractor.extract_mentions_or_lists_with_indices(text), options) do |name|
-          yield(name)
-        end
-      else
-        auto_link_entities(text, Extractor.extract_mentions_or_lists_with_indices(text), options)
-      end
+    def auto_link_usernames_or_lists(text, options = {}, &block) # :yields: list_or_username
+      auto_link_entities(text, Extractor.extract_mentions_or_lists_with_indices(text), options, &block)
     end
 
     # Add <tt><a></a></tt> tags around the hashtags in the provided <tt>text</tt>. The
@@ -201,14 +195,8 @@ module Twitter
     # <tt>:hashtag_url_base</tt>::      the value for <tt>href</tt> attribute. The hashtag text (minus the <tt>#</tt>) will be appended at the end of this.
     # <tt>:suppress_no_follow</tt>::   Do not add <tt>rel="nofollow"</tt> to auto-linked items
     # <tt>:target</tt>::   add <tt>target="window_name"</tt> to auto-linked items
-    def auto_link_hashtags(text, options = {})  # :yields: hashtag_text
-      if block_given?
-        auto_link_entities(text, Extractor.extract_hashtags_with_indices(text), options) do |hashtag|
-          yield(hashtag)
-        end
-      else
-        auto_link_entities(text, Extractor.extract_hashtags_with_indices(text), options)
-      end
+    def auto_link_hashtags(text, options = {}, &block)  # :yields: hashtag_text
+      auto_link_entities(text, Extractor.extract_hashtags_with_indices(text), options, &block)
     end
 
     # Add <tt><a></a></tt> tags around the URLs in the provided <tt>text</tt>. Any

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -24,20 +24,6 @@ module Twitter
                               :username_url_block, :list_url_block, :hashtag_url_block, :link_url_block,
                               :username_include_symbol, :suppress_lists, :suppress_no_follow, :url_entities]
 
-    HTML_ENTITIES = {
-      '&' => '&amp;',
-      '>' => '&gt;',
-      '<' => '&lt;',
-      '"' => '&quot;',
-      "'" => '&#39;'
-    }
-
-    def html_escape(text)
-      text && text.to_s.gsub(/[&"'><]/) do |character|
-        HTML_ENTITIES[character]
-      end
-    end
-
     def auto_link_entities(text, entities, options)
       return text if entities.empty?
 
@@ -239,6 +225,23 @@ module Twitter
     end
 
     private
+
+    HTML_ENTITIES = {
+      '&' => '&amp;',
+      '>' => '&gt;',
+      '<' => '&lt;',
+      '"' => '&quot;',
+      "'" => '&#39;'
+    }
+
+    def html_escape(text)
+      text && text.to_s.gsub(/[&"'><]/) do |character|
+        HTML_ENTITIES[character]
+      end
+    end
+
+    # We will make this private in future.
+    public :html_escape
 
     BOOLEAN_ATTRIBUTES = Set.new([:disabled, :readonly, :multiple, :checked]).freeze
 

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -26,123 +26,21 @@ module Twitter
       options[:url_class] ||= DEFAULT_URL_CLASS
       options[:list_class] ||= DEFAULT_LIST_CLASS
       options[:username_class] ||= DEFAULT_USERNAME_CLASS
+      options[:hashtag_class] ||= DEFAULT_HASHTAG_CLASS
       options[:username_url_base] ||= "https://twitter.com/"
       options[:list_url_base] ||= "https://twitter.com/"
-      options[:hashtag_class] ||= DEFAULT_HASHTAG_CLASS
       options[:hashtag_url_base] ||= "https://twitter.com/#!/search?q=%23"
       options[:target] ||= DEFAULT_TARGET
-
-      extra_html = HTML_ATTR_NO_FOLLOW unless options[:suppress_no_follow]
-
-      url_entities = (options[:url_entities] || {}).inject({}){|h, e| h[e["url"]] = e; h}
+      options[:extra_html] = HTML_ATTR_NO_FOLLOW unless options[:suppress_no_follow]
+      options[:url_entities] = url_entities_hash(options[:url_entities])
 
       Twitter::Rewriter.rewrite_entities(text, entities) do |entity, chars|
         if entity[:url]
-          url = entity[:url]
-          href = if options[:link_url_block]
-            options.delete(:link_url_block).call(url)
-          else
-            html_escape(url)
-          end
-
-          display_url = url
-          link_text = html_escape(display_url)
-          if url_entities[url] && url_entities[url]["display_url"]
-            display_url = url_entities[url]["display_url"]
-            expanded_url = url_entities[url]["expanded_url"]
-            if !options[:title]
-              options[:title] = expanded_url
-            end
-
-            # Goal: If a user copies and pastes a tweet containing t.co'ed link, the resulting paste
-            # should contain the full original URL (expanded_url), not the display URL.
-            #
-            # Method: Whenever possible, we actually emit HTML that contains expanded_url, and use
-            # font-size:0 to hide those parts that should not be displayed (because they are not part of display_url).
-            # Elements with font-size:0 get copied even though they are not visible.
-            # Note that display:none doesn't work here. Elements with display:none don't get copied.
-            #
-            # Additionally, we want to *display* ellipses, but we don't want them copied.  To make this happen we
-            # wrap the ellipses in a tco-ellipsis class and provide an onCopy handler that sets display:none on
-            # everything with the tco-ellipsis class.
-            #
-            # Exception: pic.twitter.com images, for which expandedUrl = "https://twitter.com/#!/username/status/1234/photo/1
-            # For those URLs, display_url is not a substring of expanded_url, so we don't do anything special to render the elided parts.
-            # For a pic.twitter.com URL, the only elided part will be the "https://", so this is fine.
-            display_url_sans_ellipses = display_url.sub("…", "")
-            if expanded_url.include?(display_url_sans_ellipses)
-              display_url_index = expanded_url.index(display_url_sans_ellipses)
-              before_display_url = expanded_url.slice(0, display_url_index)
-              # Portion of expanded_url that comes after display_url
-              after_display_url = expanded_url.slice(display_url_index + display_url_sans_ellipses.length, 999999)
-              preceding_ellipsis = display_url.match(/^…/) ? "…" : ""
-              following_ellipsis = display_url.match(/…$/) ? "…" : ""
-              # As an example: The user tweets "hi http://longdomainname.com/foo"
-              # This gets shortened to "hi http://t.co/xyzabc", with display_url = "…nname.com/foo"
-              # This will get rendered as:
-              # <span class='tco-ellipsis'> <!-- This stuff should get displayed but not copied -->
-              #   …
-              #   <!-- There's a chance the onCopy event handler might not fire. In case that happens,
-              #        we include an &nbsp; here so that the … doesn't bump up against the URL and ruin it.
-              #        The &nbsp; is inside the tco-ellipsis span so that when the onCopy handler *does*
-              #        fire, it doesn't get copied.  Otherwise the copied text would have two spaces in a row,
-              #        e.g. "hi  http://longdomainname.com/foo".
-              #   <span style='font-size:0'>&nbsp;</span>
-              # </span>
-              # <span style='font-size:0'>  <!-- This stuff should get copied but not displayed -->
-              #   http://longdomai
-              # </span>
-              # <span class='js-display-url'> <!-- This stuff should get displayed *and* copied -->
-              #   nname.com/foo
-              # </span>
-              # <span class='tco-ellipsis'> <!-- This stuff should get displayed but not copied -->
-              #   <span style='font-size:0'>&nbsp;</span>
-              #   …
-              # </span>
-              invisible = "style='font-size:0; line-height:0'"
-              link_text = "<span class='tco-ellipsis'>#{preceding_ellipsis}<span #{invisible}>&nbsp;</span></span><span #{invisible}>#{html_escape before_display_url}</span><span class='js-display-url'>#{html_escape display_url_sans_ellipses}</span><span #{invisible}>#{after_display_url}</span><span class='tco-ellipsis'><span #{invisible}>&nbsp;</span>#{following_ellipsis}</span>"
-            end
-          end
-
-          # FIXME should merge with other options like class specifications.
-          options[:html_attrs] ||= {}
-          options[:html_attrs][:class]  = options[:url_class]
-          options[:html_attrs][:target] = options[:target]
-          options[:html_attrs][:rel]    = "nofollow" unless options[:suppress_no_follow]
-          html_attrs = autolink_html_attrs(options[:html_attrs])
-
-          %(<a href="#{href}"#{html_attrs}>#{link_text}</a>)
+          link_to_url(entity, chars, options)
         elsif entity[:hashtag]
-          hashtag = entity[:hashtag]
-          hash = chars[entity[:indices].first]
-          yield(hashtag) if block_given?
-          href = if options[:hashtag_url_block]
-            options[:hashtag_url_block].call(hashtag)
-          else
-            "#{options[:hashtag_url_base]}#{html_escape(hashtag)}"
-          end
-          %(<a href="#{href}" title="##{html_escape(hashtag)}" #{target_tag(options)}class="#{options[:url_class]} #{options[:hashtag_class]}"#{extra_html}>#{hash}#{html_escape(hashtag)}</a>)
+          link_to_hashtag(entity, chars, options)
         elsif entity[:screen_name]
-          name = "#{entity[:screen_name]}#{entity[:list_slug]}"
-          chunk = block_given? ? yield(name) : name
-          at = options[:username_include_symbol] ? '' : chars[entity[:indices].first]
-          at_before_user = options[:username_include_symbol] ? chars[entity[:indices].first] : ''
-
-          if !entity[:list_slug].empty? && !options[:suppress_lists]
-            href = if options[:list_url_block]
-              options[:list_url_block].call(name.downcase)
-            else
-              "#{html_escape(options[:list_url_base])}#{html_escape(name.downcase)}"
-            end
-            %(#{at}<a class="#{options[:url_class]} #{options[:list_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(at_before_user + chunk)}</a>)
-          else
-            href = if options[:username_url_block]
-              options[:username_url_block].call(chunk)
-            else
-              "#{html_escape(options[:username_url_base])}#{html_escape(chunk)}"
-            end
-            %(#{at}<a class="#{options[:url_class]} #{options[:username_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(at_before_user + chunk)}</a>)
-          end
+          link_to_screen_name(entity, chars, options)
         end
       end
     end
@@ -261,9 +159,17 @@ module Twitter
         if BOOLEAN_ATTRIBUTES.include?(key)
           value = value ? key : nil
         end
-        if !value.nil?
+
+        unless value.nil?
+          value = case value
+          when Array
+            value.compact.join(" ")
+          else
+            value
+          end
           attrs << %( #{html_escape(key)}="#{html_escape(value)}")
         end
+
         attrs
       end
     end
@@ -274,6 +180,127 @@ module Twitter
         ""
       else
         "target=\"#{html_escape(target_option)}\""
+      end
+    end
+
+    def url_entities_hash(url_entities)
+      (url_entities || {}).inject({}) do |entities, entity|
+        entities[entity["url"]] = entity
+        entities
+      end
+    end
+
+    def link_to_url(entity, chars, options = {})
+      url_entities = options[:url_entities] || {}
+
+      url = entity[:url]
+      href = if options[:link_url_block]
+        options.delete(:link_url_block).call(url)
+      else
+        html_escape(url)
+      end
+
+      display_url = url
+      link_text = html_escape(display_url)
+      if url_entities[url] && url_entities[url]["display_url"]
+        display_url = url_entities[url]["display_url"]
+        expanded_url = url_entities[url]["expanded_url"]
+        if !options[:title]
+          options[:title] = expanded_url
+        end
+
+        # Goal: If a user copies and pastes a tweet containing t.co'ed link, the resulting paste
+        # should contain the full original URL (expanded_url), not the display URL.
+        #
+        # Method: Whenever possible, we actually emit HTML that contains expanded_url, and use
+        # font-size:0 to hide those parts that should not be displayed (because they are not part of display_url).
+        # Elements with font-size:0 get copied even though they are not visible.
+        # Note that display:none doesn't work here. Elements with display:none don't get copied.
+        #
+        # Additionally, we want to *display* ellipses, but we don't want them copied.  To make this happen we
+        # wrap the ellipses in a tco-ellipsis class and provide an onCopy handler that sets display:none on
+        # everything with the tco-ellipsis class.
+        #
+        # Exception: pic.twitter.com images, for which expandedUrl = "https://twitter.com/#!/username/status/1234/photo/1
+        # For those URLs, display_url is not a substring of expanded_url, so we don't do anything special to render the elided parts.
+        # For a pic.twitter.com URL, the only elided part will be the "https://", so this is fine.
+        display_url_sans_ellipses = display_url.sub("…", "")
+        if expanded_url.include?(display_url_sans_ellipses)
+          display_url_index = expanded_url.index(display_url_sans_ellipses)
+          before_display_url = expanded_url.slice(0, display_url_index)
+          # Portion of expanded_url that comes after display_url
+          after_display_url = expanded_url.slice(display_url_index + display_url_sans_ellipses.length, 999999)
+          preceding_ellipsis = display_url.match(/^…/) ? "…" : ""
+          following_ellipsis = display_url.match(/…$/) ? "…" : ""
+          # As an example: The user tweets "hi http://longdomainname.com/foo"
+          # This gets shortened to "hi http://t.co/xyzabc", with display_url = "…nname.com/foo"
+          # This will get rendered as:
+          # <span class='tco-ellipsis'> <!-- This stuff should get displayed but not copied -->
+          #   …
+          #   <!-- There's a chance the onCopy event handler might not fire. In case that happens,
+          #        we include an &nbsp; here so that the … doesn't bump up against the URL and ruin it.
+          #        The &nbsp; is inside the tco-ellipsis span so that when the onCopy handler *does*
+          #        fire, it doesn't get copied.  Otherwise the copied text would have two spaces in a row,
+          #        e.g. "hi  http://longdomainname.com/foo".
+          #   <span style='font-size:0'>&nbsp;</span>
+          # </span>
+          # <span style='font-size:0'>  <!-- This stuff should get copied but not displayed -->
+          #   http://longdomai
+          # </span>
+          # <span class='js-display-url'> <!-- This stuff should get displayed *and* copied -->
+          #   nname.com/foo
+          # </span>
+          # <span class='tco-ellipsis'> <!-- This stuff should get displayed but not copied -->
+          #   <span style='font-size:0'>&nbsp;</span>
+          #   …
+          # </span>
+          invisible = "style='font-size:0; line-height:0'"
+          link_text = "<span class='tco-ellipsis'>#{preceding_ellipsis}<span #{invisible}>&nbsp;</span></span><span #{invisible}>#{html_escape before_display_url}</span><span class='js-display-url'>#{html_escape display_url_sans_ellipses}</span><span #{invisible}>#{after_display_url}</span><span class='tco-ellipsis'><span #{invisible}>&nbsp;</span>#{following_ellipsis}</span>"
+        end
+      end
+
+      # FIXME should merge with other options like class specifications.
+      options[:html_attrs] ||= {}
+      options[:html_attrs][:class]  = options[:url_class]
+      options[:html_attrs][:target] = options[:target]
+      options[:html_attrs][:rel]    = "nofollow" unless options[:suppress_no_follow]
+      html_attrs = autolink_html_attrs(options[:html_attrs])
+
+      %(<a href="#{href}"#{html_attrs}>#{link_text}</a>)
+    end
+
+    def link_to_hashtag(entity, chars, options = {})
+      hashtag = entity[:hashtag]
+      hash = chars[entity[:indices].first]
+      yield(hashtag) if block_given?
+      href = if options[:hashtag_url_block]
+        options[:hashtag_url_block].call(hashtag)
+      else
+        "#{options[:hashtag_url_base]}#{html_escape(hashtag)}"
+      end
+      %(<a href="#{href}" title="##{html_escape(hashtag)}" #{target_tag(options)}class="#{options[:url_class]} #{options[:hashtag_class]}"#{options[:extra_html]}>#{hash}#{html_escape(hashtag)}</a>)
+    end
+
+    def link_to_screen_name(entity, chars, options = {})
+      name = "#{entity[:screen_name]}#{entity[:list_slug]}"
+      chunk = block_given? ? yield(name) : name
+      at = options[:username_include_symbol] ? '' : chars[entity[:indices].first]
+      at_before_user = options[:username_include_symbol] ? chars[entity[:indices].first] : ''
+
+      if !entity[:list_slug].empty? && !options[:suppress_lists]
+        href = if options[:list_url_block]
+          options[:list_url_block].call(name.downcase)
+        else
+          "#{html_escape(options[:list_url_base])}#{html_escape(name.downcase)}"
+        end
+        %(#{at}<a class="#{options[:url_class]} #{options[:list_class]}" #{target_tag(options)}href="#{href}"#{options[:extra_html]}>#{html_escape(at_before_user + chunk)}</a>)
+      else
+        href = if options[:username_url_block]
+          options[:username_url_block].call(chunk)
+        else
+          "#{html_escape(options[:username_url_base])}#{html_escape(chunk)}"
+        end
+        %(#{at}<a class="#{options[:url_class]} #{options[:username_class]}" #{target_tag(options)}href="#{href}"#{options[:extra_html]}>#{html_escape(at_before_user + chunk)}</a>)
       end
     end
   end

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -160,9 +160,9 @@ module Twitter
         url
       end
 
-      html_attrs = {
-        :class => options[:url_class]
-      }.merge(options[:html_attrs])
+      # NOTE auto link to urls do not use any default values and options
+      # like url_class but use suppress_no_follow.
+      html_attrs = options[:html_attrs].dup
 
       url_entities = url_entities_hash(options[:url_entities])
 

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -18,11 +18,6 @@ module Twitter
     DEFAULT_TARGET = nil
     # HTML attribute for robot nofollow behavior (default)
     HTML_ATTR_NO_FOLLOW = " rel=\"nofollow\""
-    # Options which should not be passed as HTML attributes
-    OPTIONS_NOT_ATTRIBUTES = [:url_class, :list_class, :username_class, :hashtag_class,
-                              :username_url_base, :list_url_base, :hashtag_url_base,
-                              :username_url_block, :list_url_block, :hashtag_url_block, :link_url_block,
-                              :username_include_symbol, :suppress_lists, :suppress_no_follow, :url_entities]
 
     def auto_link_entities(text, entities, options)
       return text if entities.empty?
@@ -243,11 +238,19 @@ module Twitter
     # We will make this private in future.
     public :html_escape
 
-    BOOLEAN_ATTRIBUTES = Set.new([:disabled, :readonly, :multiple, :checked]).freeze
+    # Options which should not be passed as HTML attributes
+    OPTIONS_NOT_ATTRIBUTES = Set.new([
+      :url_class, :list_class, :username_class, :hashtag_class,
+      :username_url_base, :list_url_base, :hashtag_url_base,
+      :username_url_block, :list_url_block, :hashtag_url_block, :link_url_block,
+      :username_include_symbol, :suppress_lists, :suppress_no_follow, :url_entities
+    ]).freeze
 
     def html_attrs_for_options(options)
       autolink_html_attrs options.reject{|k, v| OPTIONS_NOT_ATTRIBUTES.include?(k)}
     end
+
+    BOOLEAN_ATTRIBUTES = Set.new([:disabled, :readonly, :multiple, :checked]).freeze
 
     def autolink_html_attrs(options)
       options.inject("") do |attrs, (key, value)|

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -92,7 +92,7 @@ module Twitter
             # Additionally, we want to *display* ellipses, but we don't want them copied.  To make this happen we
             # wrap the ellipses in a tco-ellipsis class and provide an onCopy handler that sets display:none on
             # everything with the tco-ellipsis class.
-            # 
+            #
             # Exception: pic.twitter.com images, for which expandedUrl = "https://twitter.com/#!/username/status/1234/photo/1
             # For those URLs, display_url is not a substring of expanded_url, so we don't do anything special to render the elided parts.
             # For a pic.twitter.com URL, the only elided part will be the "https://", so this is fine.

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -6,59 +6,61 @@ module Twitter
   # A module for including Tweet auto-linking in a class. The primary use of this is for helpers/views so they can auto-link
   # usernames, lists, hashtags and URLs.
   module Autolink extend self
-    # Add <tt><a></a></tt> tags around the usernames, lists, hashtags and URLs in the provided <tt>text</tt>. The
-    # <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt>
-    # hash:
+    # Add <tt><a></a></tt> tags around the usernames, lists, hashtags and URLs in the provided <tt>text</tt>.
+    # The <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt> hash:
+    # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
+    # and place in the <tt><a></tt> tag.
     #
-    # <tt>:url_class</tt>::     class to add to all <tt><a></tt> tags
-    # <tt>:list_class</tt>::    class to add to list <tt><a></tt> tags
-    # <tt>:username_class</tt>::    class to add to username <tt><a></tt> tags
-    # <tt>:hashtag_class</tt>::    class to add to hashtag <tt><a></tt> tags
-    # <tt>:username_url_base</tt>::      the value for <tt>href</tt> attribute on username links. The <tt>@username</tt> (minus the <tt>@</tt>) will be appended at the end of this.
+    # <tt>:url_class</tt>::      class to add to all <tt><a></tt> tags
+    # <tt>:list_class</tt>::     class to add to list <tt><a></tt> tags
+    # <tt>:username_class</tt>:: class to add to username <tt><a></tt> tags
+    # <tt>:hashtag_class</tt>::  class to add to hashtag <tt><a></tt> tags
+    # <tt>:username_url_base</tt>::  the value for <tt>href</tt> attribute on username links. The <tt>@username</tt> (minus the <tt>@</tt>) will be appended at the end of this.
     # <tt>:list_url_base</tt>::      the value for <tt>href</tt> attribute on list links. The <tt>@username/list</tt> (minus the <tt>@</tt>) will be appended at the end of this.
-    # <tt>:hashtag_url_base</tt>::      the value for <tt>href</tt> attribute on hashtag links. The <tt>#hashtag</tt> (minus the <tt>#</tt>) will be appended at the end of this.
-    # <tt>:username_include_symbol</tt>::    place the <tt>@</tt> symbol within username and list links
-    # <tt>:suppress_lists</tt>::    disable auto-linking to lists
-    # <tt>:suppress_no_follow</tt>::   Do not add <tt>rel="nofollow"</tt> to auto-linked items
-    # <tt>:target</tt>::   add <tt>target="window_name"</tt> to auto-linked items
+    # <tt>:hashtag_url_base</tt>::   the value for <tt>href</tt> attribute on hashtag links. The <tt>#hashtag</tt> (minus the <tt>#</tt>) will be appended at the end of this.
+    # <tt>:username_include_symbol</tt>:: place the <tt>@</tt> symbol within username and list links
+    # <tt>:suppress_lists</tt>::          disable auto-linking to lists
+    # <tt>:suppress_no_follow</tt>::      do not add <tt>rel="nofollow"</tt> to auto-linked items
     def auto_link(text, options = {}, &block)
       auto_link_entities(text, Extractor.extract_entities_with_indices(text, :extract_url_without_protocol => false), options, &block)
     end
 
     # Add <tt><a></a></tt> tags around the usernames and lists in the provided <tt>text</tt>. The
-    # <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt>
-    # hash:
+    # <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt> hash.
+    # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
+    # and place in the <tt><a></tt> tag.
     #
-    # <tt>:url_class</tt>::     class to add to all <tt><a></tt> tags
-    # <tt>:list_class</tt>::    class to add to list <tt><a></tt> tags
-    # <tt>:username_class</tt>::    class to add to username <tt><a></tt> tags
-    # <tt>:username_url_base</tt>::      the value for <tt>href</tt> attribute on username links. The <tt>@username</tt> (minus the <tt>@</tt>) will be appended at the end of this.
-    # <tt>:username_include_symbol</tt>::    place the <tt>@</tt> symbol within username and list links
-    # <tt>:list_url_base</tt>::      the value for <tt>href</tt> attribute on list links. The <tt>@username/list</tt> (minus the <tt>@</tt>) will be appended at the end of this.
-    # <tt>:suppress_lists</tt>::    disable auto-linking to lists
-    # <tt>:suppress_no_follow</tt>::   Do not add <tt>rel="nofollow"</tt> to auto-linked items
-    # <tt>:target</tt>::   add <tt>target="window_name"</tt> to auto-linked items
+    # <tt>:url_class</tt>::      class to add to all <tt><a></tt> tags
+    # <tt>:list_class</tt>::     class to add to list <tt><a></tt> tags
+    # <tt>:username_class</tt>:: class to add to username <tt><a></tt> tags
+    # <tt>:username_url_base</tt>:: the value for <tt>href</tt> attribute on username links. The <tt>@username</tt> (minus the <tt>@</tt>) will be appended at the end of this.
+    # <tt>:list_url_base</tt>::     the value for <tt>href</tt> attribute on list links. The <tt>@username/list</tt> (minus the <tt>@</tt>) will be appended at the end of this.
+    # <tt>:username_include_symbol</tt>:: place the <tt>@</tt> symbol within username and list links
+    # <tt>:suppress_lists</tt>::          disable auto-linking to lists
+    # <tt>:suppress_no_follow</tt>::      do not add <tt>rel="nofollow"</tt> to auto-linked items
     def auto_link_usernames_or_lists(text, options = {}, &block) # :yields: list_or_username
       auto_link_entities(text, Extractor.extract_mentions_or_lists_with_indices(text), options, &block)
     end
 
-    # Add <tt><a></a></tt> tags around the hashtags in the provided <tt>text</tt>. The
-    # <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt>
-    # hash:
+    # Add <tt><a></a></tt> tags around the hashtags in the provided <tt>text</tt>.
+    # The <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt> hash.
+    # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
+    # and place in the <tt><a></tt> tag.
     #
     # <tt>:url_class</tt>::     class to add to all <tt><a></tt> tags
     # <tt>:hashtag_class</tt>:: class to add to hashtag <tt><a></tt> tags
-    # <tt>:hashtag_url_base</tt>::      the value for <tt>href</tt> attribute. The hashtag text (minus the <tt>#</tt>) will be appended at the end of this.
-    # <tt>:suppress_no_follow</tt>::   Do not add <tt>rel="nofollow"</tt> to auto-linked items
-    # <tt>:target</tt>::   add <tt>target="window_name"</tt> to auto-linked items
+    # <tt>:hashtag_url_base</tt>:: the value for <tt>href</tt> attribute. The hashtag text (minus the <tt>#</tt>) will be appended at the end of this.
+    # <tt>:suppress_no_follow</tt>:: do not add <tt>rel="nofollow"</tt> to auto-linked items
     def auto_link_hashtags(text, options = {}, &block)  # :yields: hashtag_text
       auto_link_entities(text, Extractor.extract_hashtags_with_indices(text), options, &block)
     end
 
-    # Add <tt><a></a></tt> tags around the URLs in the provided <tt>text</tt>. Any
-    # elements in the <tt>href_options</tt> hash will be converted to HTML attributes
-    # and place in the <tt><a></tt> tag. Unless <tt>href_options</tt> contains <tt>:suppress_no_follow</tt>
-    # the <tt>rel="nofollow"</tt> attribute will be added.
+    # Add <tt><a></a></tt> tags around the URLs in the provided <tt>text</tt>.
+    # The <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt> hash.
+    # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
+    # and place in the <tt><a></tt> tag.
+    #
+    # <tt>:suppress_no_follow</tt>:: do not add <tt>rel="nofollow"</tt> to auto-linked items
     def auto_link_urls(text, options = {}, &block)
       auto_link_entities(text, Extractor.extract_urls_with_indices(text, :extract_url_without_protocol => false), options, &block)
     end
@@ -66,6 +68,12 @@ module Twitter
     # These methods are deprecated, will be removed in future.
     extend Deprecation
 
+    # <b>Deprecated</b>: Please use auto_link_urls instead.
+    # Add <tt><a></a></tt> tags around the URLs in the provided <tt>text</tt>.
+    # Any elements in the <tt>href_options</tt> hash will be converted to HTML attributes
+    # and place in the <tt><a></tt> tag.
+    # Unless <tt>href_options</tt> contains <tt>:suppress_no_follow</tt>
+    # the <tt>rel="nofollow"</tt> attribute will be added.
     alias :auto_link_urls_custom :auto_link_urls
     deprecate :auto_link_urls_custom, :auto_link_urls
 

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -157,7 +157,7 @@ module Twitter
       href = if options[:link_url_block]
         options[:link_url_block].call(url)
       else
-        html_escape(url)
+        url
       end
 
       html_attrs = {
@@ -173,7 +173,7 @@ module Twitter
         html_escape(url)
       end
 
-      link_to(link_text, href, html_attrs)
+      link_to(link_text, href, html_attrs, :no_escape_text => true)
     end
 
     INVISIBLE_TAG_ATTRS = "style='font-size:0; line-height:0'".freeze
@@ -246,7 +246,7 @@ module Twitter
       href = if options[:hashtag_url_block]
         options[:hashtag_url_block].call(hashtag)
       else
-        "#{options[:hashtag_url_base]}#{html_escape(hashtag)}"
+        "#{options[:hashtag_url_base]}#{hashtag}"
       end
 
       html_attrs = {
@@ -254,7 +254,7 @@ module Twitter
         :title => text
       }.merge(options[:html_attrs])
 
-      link_to(html_escape(text), href, html_attrs)
+      link_to(text, href, html_attrs)
     end
 
     def link_to_screen_name(entity, chars, options = {})
@@ -278,24 +278,25 @@ module Twitter
         href = if options[:list_url_block]
           options[:list_url_block].call(name)
         else
-          "#{html_escape(options[:list_url_base])}#{html_escape(name)}"
+          "#{options[:list_url_base]}#{name}"
         end
         html_attrs[:class] ||= "#{options[:url_class]} #{options[:list_class]}"
       else
         href = if options[:username_url_block]
           options[:username_url_block].call(chunk)
         else
-          "#{html_escape(options[:username_url_base])}#{html_escape(name)}"
+          "#{options[:username_url_base]}#{name}"
         end
         html_attrs[:class] ||= "#{options[:url_class]} #{options[:username_class]}"
       end
 
-      "#{at}#{link_to(html_escape(text), href, html_attrs)}"
+      "#{at}#{link_to(text, href, html_attrs)}"
     end
 
-    # FIXME should place html_escape at a single place.
     def link_to(text, href, attributes = {}, options = {})
-      %(<a href="#{href}"#{tag_attrs(attributes)}>#{text}</a>)
+      attributes[:href] = href
+      text = html_escape(text) unless options[:no_escape_text]
+      %(<a#{tag_attrs(attributes)}>#{text}</a>)
     end
 
     BOOLEAN_ATTRIBUTES = Set.new([:disabled, :readonly, :multiple, :checked]).freeze

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -31,15 +31,10 @@ module Twitter
       options[:hashtag_class] ||= DEFAULT_HASHTAG_CLASS
       options[:hashtag_url_base] ||= "https://twitter.com/#!/search?q=%23"
       options[:target] ||= DEFAULT_TARGET
+
       extra_html = HTML_ATTR_NO_FOLLOW unless options[:suppress_no_follow]
 
-      url_entities = {}
-      if options[:url_entities]
-        options[:url_entities].each do |entity|
-          url_entities[entity["url"]] = entity
-        end
-        options.delete(:url_entities)
-      end
+      url_entities = (options[:url_entities] || {}).inject({}){|h, e| h[e["url"]] = e; h}
 
       Twitter::Rewriter.rewrite_entities(text, entities) do |entity, chars|
         if entity[:url]

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -62,12 +62,7 @@ module Twitter
       end
       
       html_attrs = nil
-      begin_index = 0
-      result = ""
-      chars = text.chars.to_a
-      
-      entities.each do |entity|
-        result << chars[begin_index...entity[:indices].first].to_s
+      Twitter::Rewriter.rewrite_entities(text, entities) do |entity, chars|
         if entity[:url]
           url = entity[:url]
           href = if options[:link_url_block]
@@ -82,7 +77,7 @@ module Twitter
           end
   
           html_attrs = html_attrs_for_options(options) unless html_attrs
-          result << %(<a href="#{href}"#{html_attrs}>#{html_escape(display_url)}</a>)
+          %(<a href="#{href}"#{html_attrs}>#{html_escape(display_url)}</a>)
         elsif entity[:hashtag]
           hashtag = entity[:hashtag]
           hash = chars[entity[:indices].first]
@@ -92,7 +87,7 @@ module Twitter
           else
             "#{options[:hashtag_url_base]}#{html_escape(hashtag)}"
           end
-          result << %(<a href="#{href}" title="##{html_escape(hashtag)}" #{target_tag(options)}class="#{options[:url_class]} #{options[:hashtag_class]}"#{extra_html}>#{hash}#{html_escape(hashtag)}</a>)
+          %(<a href="#{href}" title="##{html_escape(hashtag)}" #{target_tag(options)}class="#{options[:url_class]} #{options[:hashtag_class]}"#{extra_html}>#{hash}#{html_escape(hashtag)}</a>)
         elsif entity[:screen_name]
           name = "#{entity[:screen_name]}#{entity[:list_slug]}"
           chunk = block_given? ? yield(name) : name
@@ -104,21 +99,17 @@ module Twitter
             else
               "#{html_escape(options[:list_url_base])}#{html_escape(name.downcase)}"
             end
-            result << %(#{at}<a class="#{options[:url_class]} #{options[:list_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
+            %(#{at}<a class="#{options[:url_class]} #{options[:list_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
           else
             href = if options[:username_url_block]
               options[:username_url_block].call(chunk)
             else
               "#{html_escape(options[:username_url_base])}#{html_escape(chunk)}"
             end
-            result << %(#{at}<a class="#{options[:url_class]} #{options[:username_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
+            %(#{at}<a class="#{options[:url_class]} #{options[:username_class]}" #{target_tag(options)}href="#{href}"#{extra_html}>#{html_escape(chunk)}</a>)
           end
         end
-        begin_index = entity[:indices].last
       end
-      result << chars[begin_index..-1].to_s
-      
-      result
     end
 
     # Add <tt><a></a></tt> tags around the usernames, lists, hashtags and URLs in the provided <tt>text</tt>. The

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -38,7 +38,7 @@ module Twitter
 
     def auto_link_entities(text, entities, options)
       return text if entities.empty?
-      
+
       options = options.dup
       options[:class] = options[:url_class]
       options[:rel] = "nofollow" unless options[:suppress_no_follow]
@@ -51,7 +51,7 @@ module Twitter
       options[:hashtag_url_base] ||= "http://twitter.com/#!/search?q=%23"
       options[:target] ||= DEFAULT_TARGET
       extra_html = HTML_ATTR_NO_FOLLOW unless options[:suppress_no_follow]
-      
+
       url_entities = {}
       if options[:url_entities]
         options[:url_entities].each do |entity|
@@ -60,7 +60,7 @@ module Twitter
         end
         options.delete(:url_entities)
       end
-      
+
       html_attrs = nil
       Twitter::Rewriter.rewrite_entities(text, entities) do |entity, chars|
         if entity[:url]
@@ -70,12 +70,12 @@ module Twitter
           else
             html_escape(url)
           end
-  
+
           display_url = url
           if url_entities[url] && url_entities[url][:display_url]
             display_url = url_entities[url][:display_url]
           end
-  
+
           html_attrs = html_attrs_for_options(options) unless html_attrs
           %(<a href="#{href}"#{html_attrs}>#{html_escape(display_url)}</a>)
         elsif entity[:hashtag]
@@ -131,7 +131,7 @@ module Twitter
     def auto_link(text, options = {})
       auto_link_entities(text, Extractor.extract_entities_with_indices(text, {:extract_url_without_protocol => false}), options)
     end
-    
+
     # Add <tt><a></a></tt> tags around the usernames and lists in the provided <tt>text</tt>. The
     # <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt>
     # hash:

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -6,46 +6,6 @@ module Twitter
   # A module for including Tweet auto-linking in a class. The primary use of this is for helpers/views so they can auto-link
   # usernames, lists, hashtags and URLs.
   module Autolink extend self
-    # Default CSS class for auto-linked URLs
-    DEFAULT_URL_CLASS = "tweet-url"
-    # Default CSS class for auto-linked lists (along with the url class)
-    DEFAULT_LIST_CLASS = "list-slug"
-    # Default CSS class for auto-linked usernames (along with the url class)
-    DEFAULT_USERNAME_CLASS = "username"
-    # Default CSS class for auto-linked hashtags (along with the url class)
-    DEFAULT_HASHTAG_CLASS = "hashtag"
-
-    def auto_link_entities(text, entities, options)
-      return text if entities.empty?
-
-      options = options.dup
-      options[:url_class] ||= DEFAULT_URL_CLASS
-      options[:list_class] ||= DEFAULT_LIST_CLASS
-      options[:username_class] ||= DEFAULT_USERNAME_CLASS
-      options[:hashtag_class] ||= DEFAULT_HASHTAG_CLASS
-      options[:username_url_base] ||= "https://twitter.com/"
-      options[:list_url_base] ||= "https://twitter.com/"
-      options[:hashtag_url_base] ||= "https://twitter.com/#!/search?q=%23"
-      options[:url_entities] = url_entities_hash(options[:url_entities])
-
-      # FIXME deprecate this code.
-      options[:html_attrs] ||= {}
-      options[:html_attrs][:target] = options[:target]
-      options[:html_attrs][:rel]    = "nofollow" unless options[:suppress_no_follow]
-
-      Twitter::Rewriter.rewrite_entities(text, entities) do |entity, chars|
-        options[:html_attrs][:class] = [options[:url_class]]
-
-        if entity[:url]
-          link_to_url(entity, chars, options)
-        elsif entity[:hashtag]
-          link_to_hashtag(entity, chars, options)
-        elsif entity[:screen_name]
-          link_to_screen_name(entity, chars, options)
-        end
-      end
-    end
-
     # Add <tt><a></a></tt> tags around the usernames, lists, hashtags and URLs in the provided <tt>text</tt>. The
     # <tt><a></tt> tags can be controlled with the following entries in the <tt>options</tt>
     # hash:
@@ -115,6 +75,46 @@ module Twitter
     deprecate :auto_link_urls_custom, :auto_link_urls
 
     private
+
+    # Default CSS class for auto-linked URLs
+    DEFAULT_URL_CLASS = "tweet-url"
+    # Default CSS class for auto-linked lists (along with the url class)
+    DEFAULT_LIST_CLASS = "list-slug"
+    # Default CSS class for auto-linked usernames (along with the url class)
+    DEFAULT_USERNAME_CLASS = "username"
+    # Default CSS class for auto-linked hashtags (along with the url class)
+    DEFAULT_HASHTAG_CLASS = "hashtag"
+
+    def auto_link_entities(text, entities, options)
+      return text if entities.empty?
+
+      options = options.dup
+      options[:url_class] ||= DEFAULT_URL_CLASS
+      options[:list_class] ||= DEFAULT_LIST_CLASS
+      options[:username_class] ||= DEFAULT_USERNAME_CLASS
+      options[:hashtag_class] ||= DEFAULT_HASHTAG_CLASS
+      options[:username_url_base] ||= "https://twitter.com/"
+      options[:list_url_base] ||= "https://twitter.com/"
+      options[:hashtag_url_base] ||= "https://twitter.com/#!/search?q=%23"
+      options[:url_entities] = url_entities_hash(options[:url_entities])
+
+      # FIXME deprecate this code.
+      options[:html_attrs] ||= {}
+      options[:html_attrs][:target] = options[:target]
+      options[:html_attrs][:rel]    = "nofollow" unless options[:suppress_no_follow]
+
+      Twitter::Rewriter.rewrite_entities(text, entities) do |entity, chars|
+        options[:html_attrs][:class] = [options[:url_class]]
+
+        if entity[:url]
+          link_to_url(entity, chars, options)
+        elsif entity[:hashtag]
+          link_to_hashtag(entity, chars, options)
+        elsif entity[:screen_name]
+          link_to_screen_name(entity, chars, options)
+        end
+      end
+    end
 
     HTML_ENTITIES = {
       '&' => '&amp;',

--- a/lib/deprecation.rb
+++ b/lib/deprecation.rb
@@ -1,0 +1,15 @@
+module Twitter
+  module Deprecation
+    def deprecate(method, new_method = nil)
+      deprecated_method = :"deprecated_#{method}"
+      message = "Deprecation: `#{method}` is deprecated."
+      message << " Please use `#{new_method}` instead." if new_method
+
+      alias_method(deprecated_method, method)
+      define_method method do |*args, &block|
+        warn message
+        send(deprecated_method, *args, &block)
+      end
+    end
+  end
+end

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -46,15 +46,23 @@ module Twitter
   # of usernames, lists, URLs and hashtags.
   module Extractor extend self
 
+    # Extracts all usernames, lists, hashtags and URLs  in the Tweet <tt>text</tt>
+    # along with the indices for where the entity ocurred
+    # If the <tt>text</tt> is <tt>nil</tt> or contains no entity an empty array
+    # will be returned.
+    #
+    # If a block is given then it will be called for each entity.
     def extract_entities_with_indices(text, options = {})
       # extract all entities
-      entities = extract_urls_with_indices(text, options) + extract_hashtags_with_indices(text) + extract_mentions_or_lists_with_indices(text)
-      
+      entities = extract_urls_with_indices(text, options) +
+                 extract_hashtags_with_indices(text) +
+                 extract_mentions_or_lists_with_indices(text)
+
       return [] if entities.empty?
 
       # sort by start index
       entities.sort! {|a,b| a[:indices].first <=> b[:indices].first}
-      
+
       # remove duplicates
       prev = nil
       entities.each do |entity|
@@ -64,10 +72,11 @@ module Twitter
           prev = entity
         end
       end
-      
+
+      entities.each{|entity| yield entity} if block_given?
       entities
     end
-    
+
     # Extracts a list of all usernames mentioned in the Tweet <tt>text</tt>. If the
     # <tt>text</tt> is <tt>nil</tt> or contains no username mentions an empty array
     # will be returned.

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 class String
   # Helper function to count the character length by first converting to an
   # array.  This is needed because with unicode strings, the return value

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -48,24 +48,22 @@ module Twitter
 
     def extract_entities_with_indices(text, options = {})
       # extract all entities
-      entities = extract_urls_with_indices(text, options)
-      entities += extract_hashtags_with_indices(text)
-      entities += extract_mentions_or_lists_with_indices(text)
+      entities = extract_urls_with_indices(text, options) + extract_hashtags_with_indices(text) + extract_mentions_or_lists_with_indices(text)
       
+      return [] if entities.empty?
+
       # sort by start index
       entities.sort! {|a,b| a[:indices].first <=> b[:indices].first}
       
-      return [] if entities.empty?
-      
       # remove duplicates
       prev = nil
-      entities.each{|entity|
+      entities.each do |entity|
         if prev != nil && prev[:indices].last > entity[:indices].first
           entities.delete entity
         else
           prev = entity
         end
-      }
+      end
       
       entities
     end
@@ -117,7 +115,7 @@ module Twitter
     # index, and the end index in the <tt>text</tt>. The list_slug will be an empty stirng
     # if this is a username mention.
     def extract_mentions_or_lists_with_indices(text) # :yields: username, list_slug, start, end
-      return [] unless text
+      return [] unless text && text.index(/[@＠]/)
 
       possible_entries = []
       text.to_s.scan(Twitter::Regex[:valid_mention_or_list]) do |before, at, screen_name, list_slug|
@@ -175,7 +173,7 @@ module Twitter
     #
     # If a block is given then it will be called for each URL.
     def extract_urls_with_indices(text, options = {}) # :yields: url, start, end
-      return [] unless text
+      return [] unless text && text.index(".")
       urls = []
       position = 0
       extract_url_without_protocol = options[:extract_url_without_protocol]
@@ -248,7 +246,7 @@ module Twitter
     #
     # If a block is given then it will be called for each hashtag.
     def extract_hashtags_with_indices(text) # :yields: hashtag_text, start, end
-      return [] unless text
+      return [] unless text && text.index(/[#＃]/)
 
       tags = []
       text.scan(Twitter::Regex[:valid_hashtag]) do |before, hash, hash_text|

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -120,7 +120,7 @@ module Twitter
     # index, and the end index in the <tt>text</tt>. The list_slug will be an empty stirng
     # if this is a username mention.
     def extract_mentions_or_lists_with_indices(text) # :yields: username, list_slug, start, end
-      return [] unless text && text.index(/[@＠]/)
+      return [] unless text =~ /[@＠]/
 
       possible_entries = []
       text.to_s.scan(Twitter::Regex[:valid_mention_or_list]) do |before, at, screen_name, list_slug|
@@ -249,7 +249,7 @@ module Twitter
     #
     # If a block is given then it will be called for each hashtag.
     def extract_hashtags_with_indices(text) # :yields: hashtag_text, start, end
-      return [] unless text && text.index(/[#＃]/)
+      return [] unless text =~ /[#＃]/
 
       tags = []
       text.scan(Twitter::Regex[:valid_hashtag]) do |before, hash, hash_text|

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -47,7 +47,6 @@ module Twitter
   # A module for including Tweet parsing in a class. This module provides function for the extraction and processing
   # of usernames, lists, URLs and hashtags.
   module Extractor extend self
-
     # Extracts all usernames, lists, hashtags and URLs  in the Tweet <tt>text</tt>
     # along with the indices for where the entity ocurred
     # If the <tt>text</tt> is <tt>nil</tt> or contains no entity an empty array
@@ -108,6 +107,7 @@ module Twitter
           yield mention[:screen_name], mention[:indices].first, mention[:indices].last
         end
       end
+
       possible_screen_names
     end
 
@@ -226,7 +226,7 @@ module Twitter
           }
         end
       end
-      urls.each{|url| yield url[:url], url[:indices].first, url[:indices].last } if block_given?
+      urls.each{|url| yield url[:url], url[:indices].first, url[:indices].last} if block_given?
       urls
     end
 
@@ -264,7 +264,7 @@ module Twitter
           }
         end
       end
-      tags.each{|tag| yield tag[:hashtag], tag[:indices].first, tag[:indices].last } if block_given?
+      tags.each{|tag| yield tag[:hashtag], tag[:indices].first, tag[:indices].last} if block_given?
       tags
     end
   end

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -176,7 +176,6 @@ module Twitter
       return [] unless text && (options[:extract_url_without_protocol] ? text.index(".") : text.index(":"))
       urls = []
       position = 0
-      extract_url_without_protocol = options[:extract_url_without_protocol]
 
       text.to_s.scan(Twitter::Regex[:valid_url]) do |all, before, url, protocol, domain, port, path, query|
         valid_url_match_data = $~
@@ -187,7 +186,7 @@ module Twitter
         # If protocol is missing and domain contains non-ASCII characters,
         # extract ASCII-only domains.
         if !protocol
-          next if !extract_url_without_protocol || before =~ Twitter::Regex[:invalid_url_without_protocol_preceding_chars]
+          next if !options[:extract_url_without_protocol] || before =~ Twitter::Regex[:invalid_url_without_protocol_preceding_chars]
           last_url = nil
           last_url_invalid_match = nil
           domain.scan(Twitter::Regex[:valid_ascii_domain]) do |ascii_domain|

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -78,10 +78,10 @@ module Twitter
     # will be returned.
     #
     # If a block is given then it will be called for each username.
-    def extract_mentioned_screen_names(text) # :yields: username
-      screen_names_only = extract_mentioned_screen_names_with_indices(text).map{|mention| mention[:screen_name] }
-      screen_names_only.each{|mention| yield mention } if block_given?
-      screen_names_only
+    def extract_mentioned_screen_names(text, &block) # :yields: username
+      screen_names = extract_mentioned_screen_names_with_indices(text).map{|m| m[:screen_name]}
+      screen_names.each(&block) if block_given?
+      screen_names
     end
 
     # Extracts a list of all usernames mentioned in the Tweet <tt>text</tt>
@@ -166,10 +166,10 @@ module Twitter
     # will be returned.
     #
     # If a block is given then it will be called for each URL.
-    def extract_urls(text) # :yields: url
-      urls_only = extract_urls_with_indices(text).map{|url| url[:url] }
-      urls_only.each{|url| yield url } if block_given?
-      urls_only
+    def extract_urls(text, &block) # :yields: url
+      urls = extract_urls_with_indices(text).map{|u| u[:url]}
+      urls.each(&block) if block_given?
+      urls
     end
 
     # Extracts a list of all URLs included in the Tweet <tt>text</tt> along
@@ -236,10 +236,10 @@ module Twitter
     # character.
     #
     # If a block is given then it will be called for each hashtag.
-    def extract_hashtags(text) # :yields: hashtag_text
-      hashtags_only = extract_hashtags_with_indices(text).map{|hash| hash[:hashtag] }
-      hashtags_only.each{|hash| yield hash } if block_given?
-      hashtags_only
+    def extract_hashtags(text, &block) # :yields: hashtag_text
+      hashtags = extract_hashtags_with_indices(text).map{|h| h[:hashtag]}
+      hashtags.each(&block) if block_given?
+      hashtags
     end
 
     # Extracts a list of all hashtags included in the Tweet <tt>text</tt>. If the

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -62,7 +62,7 @@ module Twitter
       return [] if entities.empty?
 
       # sort by start index
-      entities.sort!{|a,b| a[:indices].first <=> b[:indices].first}
+      entities = entities.sort_by{|entity| entity[:indices].first}
 
       # remove duplicates
       prev = nil

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -172,12 +172,11 @@ module Twitter
     # URLs an empty array will be returned.
     #
     # If a block is given then it will be called for each URL.
-    def extract_urls_with_indices(text, options = {}) # :yields: url, start, end
-      return [] unless text && text.index(".")
+    def extract_urls_with_indices(text, options = {:extract_url_without_protocol => true}) # :yields: url, start, end
+      return [] unless text && (options[:extract_url_without_protocol] ? text.index(".") : text.index(":"))
       urls = []
       position = 0
       extract_url_without_protocol = options[:extract_url_without_protocol]
-      extract_url_without_protocol = true if extract_url_without_protocol == nil
 
       text.to_s.scan(Twitter::Regex[:valid_url]) do |all, before, url, protocol, domain, port, path, query|
         valid_url_match_data = $~
@@ -188,7 +187,7 @@ module Twitter
         # If protocol is missing and domain contains non-ASCII characters,
         # extract ASCII-only domains.
         if !protocol
-          next if !extract_url_without_protocol
+          next if !extract_url_without_protocol || before =~ Twitter::Regex[:invalid_url_without_protocol_preceding_chars]
           last_url = nil
           last_url_invalid_match = nil
           domain.scan(Twitter::Regex[:valid_ascii_domain]) do |ascii_domain|

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -54,7 +54,7 @@ module Twitter
     # will be returned.
     #
     # If a block is given then it will be called for each entity.
-    def extract_entities_with_indices(text, options = {})
+    def extract_entities_with_indices(text, options = {}, &block)
       # extract all entities
       entities = extract_urls_with_indices(text, options) +
                  extract_hashtags_with_indices(text) +
@@ -63,19 +63,13 @@ module Twitter
       return [] if entities.empty?
 
       # sort by start index
-      entities.sort! {|a,b| a[:indices].first <=> b[:indices].first}
+      entities.sort!{|a,b| a[:indices].first <=> b[:indices].first}
 
       # remove duplicates
       prev = nil
-      entities.each do |entity|
-        if prev != nil && prev[:indices].last > entity[:indices].first
-          entities.delete entity
-        else
-          prev = entity
-        end
-      end
+      entities.reject!{|entity| (prev && prev[:indices].last > entity[:indices].first) || (prev = entity) && false}
 
-      entities.each{|entity| yield entity} if block_given?
+      entities.each(&block) if block_given?
       entities
     end
 

--- a/lib/regex.rb
+++ b/lib/regex.rb
@@ -122,7 +122,7 @@ module Twitter
     HASHTAG = /(#{HASHTAG_BOUNDARY})(#|＃)(#{HASHTAG_ALPHANUMERIC}*#{HASHTAG_ALPHA}#{HASHTAG_ALPHANUMERIC}*)/io
 
     REGEXEN[:valid_hashtag] = /#{HASHTAG}/io
-    # Used in Extractor and Rewriter for final filtering
+    # Used in Extractor for final filtering
     REGEXEN[:end_hashtag_match] = /\A(?:[#＃]|:\/\/)/o
 
     REGEXEN[:valid_mention_preceding_chars] = /(?:[^a-zA-Z0-9_!#\$%&*@＠]|^|RT:?)/o
@@ -134,7 +134,7 @@ module Twitter
       (\/[a-zA-Z][a-zA-Z0-9_\-]{0,24})?             # $4: List (optional)
     /ox
     REGEXEN[:valid_reply] = /^(?:#{REGEXEN[:spaces]})*#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})/o
-    # Used in Extractor and Rewriter for final filtering
+    # Used in Extractor for final filtering
     REGEXEN[:end_mention_match] = /\A(?:#{REGEXEN[:at_signs]}|#{REGEXEN[:latin_accents]}|:\/\/)/o
 
     # URL related hash regex collection

--- a/lib/regex.rb
+++ b/lib/regex.rb
@@ -121,7 +121,8 @@ module Twitter
     REGEXEN[:end_mention_match] = /\A(?:#{REGEXEN[:at_signs]}|#{REGEXEN[:latin_accents]}|:\/\/)/o
 
     # URL related hash regex collection
-    REGEXEN[:valid_url_preceding_chars] = /(?:[^-\/"'!=A-Z0-9_@＠\$#＃\.#{INVALID_CHARACTERS.join('')}]|^)/io
+    REGEXEN[:valid_url_preceding_chars] = /(?:[^A-Z0-9@＠$#＃#{INVALID_CHARACTERS.join('')}]|^)/io
+    REGEXEN[:invalid_url_without_protocol_preceding_chars] = /[-_.\/]$/
     DOMAIN_VALID_CHARS = "[^[:punct:][:space:][:blank:][:cntrl:]#{INVALID_CHARACTERS.join('')}#{UNICODE_SPACES.join('')}]"
     REGEXEN[:valid_subdomain] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[_-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io
     REGEXEN[:valid_domain_name] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io

--- a/lib/regex.rb
+++ b/lib/regex.rb
@@ -1,4 +1,5 @@
-# encoding: utf-8
+# encoding: UTF-8
+
 module Twitter
   # A collection of regular expressions for parsing Tweet text. The regular expression
   # list is frozen at load time to ensure immutability. These reular expressions are

--- a/lib/regex.rb
+++ b/lib/regex.rb
@@ -104,23 +104,24 @@ module Twitter
 
     HASHTAG = /(#{HASHTAG_BOUNDARY})(#|＃)(#{HASHTAG_ALPHANUMERIC}*#{HASHTAG_ALPHA}#{HASHTAG_ALPHANUMERIC}*)/io
 
-    REGEXEN[:auto_link_hashtags] = /#{HASHTAG}/io
+    REGEXEN[:valid_hashtag] = /#{HASHTAG}/io
     # Used in Extractor and Rewriter for final filtering
     REGEXEN[:end_hashtag_match] = /\A(?:[#＃]|:\/\/)/o
 
+    REGEXEN[:valid_mention_preceding_chars] = /(?:[^a-zA-Z0-9_]|^|RT:?)/o
     REGEXEN[:at_signs] = /[@＠]/
-    REGEXEN[:extract_mentions] = /(^|[^a-zA-Z0-9_])#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})/o
-    REGEXEN[:extract_mentions_or_lists] = /(^|[^a-zA-Z0-9_])#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})(\/[a-zA-Z][a-zA-Z0-9_\-]{0,24})?/o
-    REGEXEN[:extract_reply] = /^(?:#{REGEXEN[:spaces]})*#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})/o
+    REGEXEN[:valid_mention_or_list] = /
+      (#{REGEXEN[:valid_mention_preceding_chars]})  # $1: Preceeding character
+      (#{REGEXEN[:at_signs]})                       # $2: At mark
+      ([a-zA-Z0-9_]{1,20})                          # $3: Screen name
+      (\/[a-zA-Z][a-zA-Z0-9_\-]{0,24})?             # $4: List (optional)
+    /ox
+    REGEXEN[:valid_reply] = /^(?:#{REGEXEN[:spaces]})*#{REGEXEN[:at_signs]}([a-zA-Z0-9_]{1,20})/o
     # Used in Extractor and Rewriter for final filtering
-    REGEXEN[:end_screen_name_match] = /\A(?:#{REGEXEN[:at_signs]}|#{REGEXEN[:latin_accents]}|:\/\/)/o
-
-    REGEXEN[:auto_link_usernames_or_lists] = /([^a-zA-Z0-9_]|^|RT:?)([@＠]+)([a-zA-Z0-9_]{1,20})(\/[a-zA-Z][a-zA-Z0-9_\-]{0,24})?/o
-    REGEXEN[:auto_link_emoticon] = /(8\-\#|8\-E|\+\-\(|\`\@|\`O|\&lt;\|:~\(|\}:o\{|:\-\[|\&gt;o\&lt;|X\-\/|\[:-\]\-I\-|\/\/\/\/Ö\\\\\\\\|\(\|:\|\/\)|∑:\*\)|\( \| \))/
+    REGEXEN[:end_mention_match] = /\A(?:#{REGEXEN[:at_signs]}|#{REGEXEN[:latin_accents]}|:\/\/)/o
 
     # URL related hash regex collection
-    REGEXEN[:valid_preceding_chars] = /(?:[^-\/"'!=A-Z0-9_@＠\$#＃\.#{INVALID_CHARACTERS.join('')}]|^)/io
-
+    REGEXEN[:valid_url_preceding_chars] = /(?:[^-\/"'!=A-Z0-9_@＠\$#＃\.#{INVALID_CHARACTERS.join('')}]|^)/io
     DOMAIN_VALID_CHARS = "[^[:punct:][:space:][:blank:][:cntrl:]#{INVALID_CHARACTERS.join('')}#{UNICODE_SPACES.join('')}]"
     REGEXEN[:valid_subdomain] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[_-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io
     REGEXEN[:valid_domain_name] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io
@@ -179,7 +180,7 @@ module Twitter
     REGEXEN[:valid_url_query_ending_chars] = /[a-z0-9_&=#\/]/i
     REGEXEN[:valid_url] = %r{
       (                                                                                     #   $1 total match
-        (#{REGEXEN[:valid_preceding_chars]})                                                #   $2 Preceeding chracter
+        (#{REGEXEN[:valid_url_preceding_chars]})                                            #   $2 Preceeding chracter
         (                                                                                   #   $3 URL
           (https?:\/\/)?                                                                    #   $4 Protocol (optional)
           (#{REGEXEN[:valid_domain]})                                                       #   $5 Domain(s)

--- a/lib/rewriter.rb
+++ b/lib/rewriter.rb
@@ -2,18 +2,17 @@ module Twitter
   # A module provides base methods to rewrite usernames, lists, hashtags and URLs.
   module Rewriter extend self
     def rewrite_entities(text, entities)
-      begin_index = 0
-      result = ""
-      chars = text.to_s.chars.to_a
+      chars = text.to_s.to_char_a
 
-      entities.each do |entity|
-        result << chars[begin_index...entity[:indices].first].to_s
+      result = []
+      last_index = entities.inject(0) do |last_index, entity|
+        result << chars[last_index...entity[:indices].first]
         result << yield(entity, chars)
-        begin_index = entity[:indices].last
+        entity[:indices].last
       end
-      result << chars[begin_index..-1].to_s
+      result << chars[last_index..-1]
 
-      result
+      result.flatten.join
     end
 
     # These methods are deprecated, will be removed in future.

--- a/lib/rewriter.rb
+++ b/lib/rewriter.rb
@@ -21,7 +21,7 @@ module Twitter
 
     def rewrite(text, options = {})
       [:hashtags, :urls, :usernames_or_lists].inject(text) do |key|
-        send("rewrite_#{key}", text, &options[key]) if options[key]
+        options[key] ? send(:"rewrite_#{key}", text, &options[key]) : text
       end
     end
     deprecate :rewrite, :rewrite_entities

--- a/lib/rewriter.rb
+++ b/lib/rewriter.rb
@@ -27,27 +27,29 @@ module Twitter
     deprecate :rewrite, :rewrite_entities
 
     def rewrite_usernames_or_lists(text)
-      rewrite_entities(text, Extractor.extract_mentions_or_lists_with_indices(text)) do |entity, chars|
+      entities = Extractor.extract_mentions_or_lists_with_indices(text)
+      rewrite_entities(text, entities) do |entity, chars|
         at = chars[entity[:indices].first]
         list_slug = entity[:list_slug]
         list_slug = nil if list_slug.empty?
-        yield(at, entity[:screen_name], list_slug) if block_given?
+        yield(at, entity[:screen_name], list_slug)
       end
     end
     deprecate :rewrite_usernames_or_lists, :rewrite_entties
 
     def rewrite_hashtags(text)
-      rewrite_entities(text, Extractor.extract_hashtags_with_indices(text)) do |entity, chars|
+      entities = Extractor.extract_hashtags_with_indices(text)
+      rewrite_entities(text, entities) do |entity, chars|
         hash = chars[entity[:indices].first]
-        yield(hash, entity[:hashtag]) if block_given?
+        yield(hash, entity[:hashtag])
       end
     end
     deprecate :rewrite_hashtags, :rewrite_entties
 
     def rewrite_urls(text)
-      urls = Extractor.extract_urls_with_indices(text, {:extract_url_without_protocol=>false})
-      rewrite_entities(text, urls) do |entity, chars|
-        yield(entity[:url]) if block_given?
+      entities = Extractor.extract_urls_with_indices(text, :extract_url_without_protocol => false)
+      rewrite_entities(text, entities) do |entity, chars|
+        yield(entity[:url])
       end
     end
     deprecate :rewrite_urls, :rewrite_entties

--- a/lib/rewriter.rb
+++ b/lib/rewriter.rb
@@ -1,12 +1,6 @@
 module Twitter
   # A module provides base methods to rewrite usernames, lists, hashtags and URLs.
   module Rewriter extend self
-    def rewrite(text, options = {})
-      [:hashtags, :urls, :usernames_or_lists].inject(text) do |key|
-        send("rewrite_#{key}", text, &options[key]) if options[key]
-      end
-    end
-
     def rewrite_entities(text, entities)
       begin_index = 0
       result = ""
@@ -22,6 +16,16 @@ module Twitter
       result
     end
 
+    # These methods are deprecated, will be removed in future.
+    extend Deprecation
+
+    def rewrite(text, options = {})
+      [:hashtags, :urls, :usernames_or_lists].inject(text) do |key|
+        send("rewrite_#{key}", text, &options[key]) if options[key]
+      end
+    end
+    deprecate :rewrite, :rewrite_entities
+
     def rewrite_usernames_or_lists(text)
       rewrite_entities(text, Extractor.extract_mentions_or_lists_with_indices(text)) do |entity, chars|
         at = chars[entity[:indices].first]
@@ -30,6 +34,7 @@ module Twitter
         yield(at, entity[:screen_name], list_slug) if block_given?
       end
     end
+    deprecate :rewrite_usernames_or_lists, :rewrite_entties
 
     def rewrite_hashtags(text)
       rewrite_entities(text, Extractor.extract_hashtags_with_indices(text)) do |entity, chars|
@@ -37,6 +42,7 @@ module Twitter
         yield(hash, entity[:hashtag]) if block_given?
       end
     end
+    deprecate :rewrite_hashtags, :rewrite_entties
 
     def rewrite_urls(text)
       urls = Extractor.extract_urls_with_indices(text, {:extract_url_without_protocol=>false})
@@ -44,5 +50,6 @@ module Twitter
         yield(entity[:url]) if block_given?
       end
     end
+    deprecate :rewrite_urls, :rewrite_entties
   end
 end

--- a/lib/rewriter.rb
+++ b/lib/rewriter.rb
@@ -19,13 +19,13 @@ module Twitter
         if index % 4 != 0
           new_text << chunk
         else
-          new_text << chunk.gsub(Twitter::Regex[:auto_link_usernames_or_lists]) do
+          new_text << chunk.gsub(Twitter::Regex[:valid_mention_or_list]) do
             before, at, user, slash_listname, after = $1, $2, $3, $4, $'
             if slash_listname
               # the link is a list
               "#{before}#{yield(at, user, slash_listname)}"
             else
-              if after =~ Twitter::Regex[:end_screen_name_match]
+              if after =~ Twitter::Regex[:end_mention_match]
                 # Followed by something that means we don't autolink
                 "#{before}#{at}#{user}#{slash_listname}"
               else
@@ -41,7 +41,7 @@ module Twitter
     end
 
     def rewrite_hashtags(text)
-      text.to_s.gsub(Twitter::Regex[:auto_link_hashtags]) do
+      text.to_s.gsub(Twitter::Regex[:valid_hashtag]) do
         before, hash, hashtag, after = $1, $2, $3, $'
         if after =~ Twitter::Regex[:end_hashtag_match]
           "#{before}#{hash}#{hashtag}"

--- a/lib/rewriter.rb
+++ b/lib/rewriter.rb
@@ -34,7 +34,7 @@ module Twitter
         yield(at, entity[:screen_name], list_slug)
       end
     end
-    deprecate :rewrite_usernames_or_lists, :rewrite_entties
+    deprecate :rewrite_usernames_or_lists, :rewrite_entities
 
     def rewrite_hashtags(text)
       entities = Extractor.extract_hashtags_with_indices(text)
@@ -43,7 +43,7 @@ module Twitter
         yield(hash, entity[:hashtag])
       end
     end
-    deprecate :rewrite_hashtags, :rewrite_entties
+    deprecate :rewrite_hashtags, :rewrite_entities
 
     def rewrite_urls(text)
       entities = Extractor.extract_urls_with_indices(text, :extract_url_without_protocol => false)
@@ -51,6 +51,6 @@ module Twitter
         yield(entity[:url])
       end
     end
-    deprecate :rewrite_urls, :rewrite_entties
+    deprecate :rewrite_urls, :rewrite_entities
   end
 end

--- a/lib/twitter-text.rb
+++ b/lib/twitter-text.rb
@@ -12,6 +12,7 @@ require 'active_support'
 require 'active_support/core_ext/string/multibyte.rb'
 
 %w(
+  deprecation
   regex
   rewriter
   autolink

--- a/lib/twitter-text.rb
+++ b/lib/twitter-text.rb
@@ -11,10 +11,14 @@ end
 require 'active_support'
 require 'active_support/core_ext/string/multibyte.rb'
 
-require File.join(File.dirname(__FILE__), 'regex')
-require File.join(File.dirname(__FILE__), 'rewriter')
-require File.join(File.dirname(__FILE__), 'autolink')
-require File.join(File.dirname(__FILE__), 'extractor')
-require File.join(File.dirname(__FILE__), 'unicode')
-require File.join(File.dirname(__FILE__), 'validation')
-require File.join(File.dirname(__FILE__), 'hithighlighter')
+%w(
+  regex
+  rewriter
+  autolink
+  extractor
+  unicode
+  validation
+  hithighlighter
+).each do |name|
+  require File.expand_path("../#{name}", __FILE__)
+end

--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -52,7 +52,7 @@ module Twitter
       extracted.size == 1 && extracted.first == username[1..-1]
     end
 
-    VALID_LIST_RE = /\A#{Twitter::Regex[:auto_link_usernames_or_lists]}\z/o
+    VALID_LIST_RE = /\A#{Twitter::Regex[:valid_mention_or_list]}\z/o
     def valid_list?(username_list)
       match = username_list.match(VALID_LIST_RE)
       # Must have matched and had nothing before or after

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -309,7 +309,7 @@ describe Twitter::Autolink do
         end
 
         it "should be linked" do
-          @autolinked_text.should == "<a href=\"https://twitter.com/#!/search?q=%23éhashtag\" title=\"#éhashtag\" class=\"tweet-url hashtag\" rel=\"nofollow\">#éhashtag</a>"
+          @autolinked_text.should == "<a href=\"https://twitter.com/#!/search?q=%23éhashtag\" class=\"tweet-url hashtag\" rel=\"nofollow\" title=\"#éhashtag\">#éhashtag</a>"
         end
       end
 

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -541,6 +541,12 @@ describe Twitter::Autolink do
         auto_linked.should_not include('hashtag_classname')
       end
 
+      it "should autolink url/hashtag/mention in text with Unicode supplementary characters" do
+        auto_linked = @linker.auto_link("#{[0x10400].pack('U')} #hashtag #{[0x10400].pack('U')} @mention #{[0x10400].pack('U')} http://twitter.com/")
+        auto_linked.should have_autolinked_hashtag('#hashtag')
+        auto_linked.should link_to_screen_name('mention')
+        auto_linked.should have_autolinked_url('http://twitter.com/')
+      end
     end
 
   end

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -569,8 +569,8 @@ describe Twitter::Autolink do
       html.inner_text.should == " http://blog.twitter.com/2011/05/twitter-for-mac-update.html …"
     end
 
-    it "should apply :url_class as a CSS class" do
-      linked = TestAutolink.new.auto_link("http://example.com/", :url_class => 'myclass')
+    it "should apply :class as a CSS class" do
+      linked = TestAutolink.new.auto_link("http://example.com/", :class => 'myclass')
       linked.should have_autolinked_url('http://example.com/')
       linked.should match(/myclass/)
     end

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -309,7 +309,7 @@ describe Twitter::Autolink do
         end
 
         it "should be linked" do
-          @autolinked_text.should == "<a href=\"https://twitter.com/#!/search?q=%23éhashtag\" class=\"tweet-url hashtag\" rel=\"nofollow\" title=\"#éhashtag\">#éhashtag</a>"
+          @autolinked_text.should == "<a class=\"tweet-url hashtag\" href=\"https://twitter.com/#!/search?q=%23éhashtag\" rel=\"nofollow\" title=\"#éhashtag\">#éhashtag</a>"
         end
       end
 

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -424,10 +424,10 @@ describe Twitter::Autolink do
       end
 
       context "with a URL preceded in forbidden characters" do
-        it "should not be linked" do
+        it "should be linked" do
           matcher = TestAutolink.new
           %w| \ ' / ! = |.each do |char|
-            matcher.auto_link("#{char}#{url}").should_not have_autolinked_url(url)
+            matcher.auto_link("#{char}#{url}").should have_autolinked_url(url)
           end
         end
       end

--- a/spec/extractor_spec.rb
+++ b/spec/extractor_spec.rb
@@ -100,6 +100,10 @@ describe Twitter::Extractor do
       end
       needed.should == []
     end
+
+    it "should extract screen name in text with supplementary character" do
+      @extractor.extract_mentioned_screen_names_with_indices("#{[0x10400].pack('U')} @alice").should == [{:screen_name => "alice", :indices => [2, 8]}]
+    end
   end
 
   describe "replies" do
@@ -213,6 +217,10 @@ describe Twitter::Extractor do
           extracted_url[:indices].first.should == 11
           extracted_url[:indices].last.should == 11 + url.chars.to_a.size
         end
+      end
+
+      it "should extract URL in text with supplementary character" do
+        @extractor.extract_urls_with_indices("#{[0x10400].pack('U')} http://twitter.com").should == [{:url => "http://twitter.com", :indices => [2, 20]}]
       end
     end
 
@@ -344,6 +352,10 @@ describe Twitter::Extractor do
 
     it "should not extract numeric hashtags" do
       not_match_hashtag_in_text("#1234")
+    end
+
+    it "should extract hashtag in text with supplementary character" do
+      match_hashtag_in_text("hashtag", "#{[0x10400].pack('U')} #hashtag", 2)
     end
   end
 end

--- a/spec/rewriter_spec.rb
+++ b/spec/rewriter_spec.rb
@@ -469,11 +469,11 @@ describe Twitter::Rewriter do
     end
 
     context "with a URL preceded in forbidden characters" do
-      it "should not be rewritten" do
+      it "should be rewritten" do
         %w| \ ' / ! = |.each do |char|
           Twitter::Rewriter.rewrite_urls("#{char}#{url}") do |url|
             "[rewritten]" # should not be called here.
-          end.should == "#{char}#{url}"
+          end.should == "#{char}[rewritten]"
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ end
 
 RSpec::Matchers.define :match_autolink_expression do
   match do |string|
-    Twitter::Regex[:valid_url].match(string)
+    !Twitter::Extractor.extract_urls(string).empty?
   end
 end
 

--- a/test/conformance_test.rb
+++ b/test/conformance_test.rb
@@ -7,7 +7,7 @@ if major.to_i == 1 && minor.to_i < 9
   $KCODE='u'
 end
 
-require File.expand_path(File.dirname(__FILE__) + '/../lib/twitter-text')
+require File.expand_path('../../lib/twitter-text', __FILE__)
 
 class ConformanceTest < Test::Unit::TestCase
   include Twitter::Extractor
@@ -15,168 +15,123 @@ class ConformanceTest < Test::Unit::TestCase
   include Twitter::HitHighlighter
   include Twitter::Validation
 
-  def setup
-    @conformance_dir = ENV['CONFORMANCE_DIR'] || File.join(File.dirname(__FILE__), 'twitter-text-conformance')
-  end
-
-  module ExtractorConformance
-    def test_replies_extractor_conformance
-      run_conformance_test(File.join(@conformance_dir, 'extract.yml'), :replies) do |description, expected, input|
-        assert_equal expected, extract_reply_screen_name(input), description
-      end
-    end
-
-    def test_mentions_extractor_conformance
-      run_conformance_test(File.join(@conformance_dir, 'extract.yml'), :mentions) do |description, expected, input|
-        assert_equal expected, extract_mentioned_screen_names(input), description
-      end
-    end
-
-    def test_mentions_with_indices_extractor_conformance
-      run_conformance_test(File.join(@conformance_dir, 'extract.yml'), :mentions_with_indices) do |description, expected, input|
-        expected = expected.map{|elem| elem.inject({}){|h, (k,v)| h[k.to_sym] = v; h} }
-        assert_equal expected, extract_mentioned_screen_names_with_indices(input), description
-      end
-    end
-
-    def test_mentions_or_lists_with_indices_conformance
-      run_conformance_test(File.join(@conformance_dir, 'extract.yml'), :mentions_or_lists_with_indices) do |description, expected, input|
-        expected = expected.map{|elem| elem.inject({}){|h, (k,v)| h[k.to_sym] = v; h} }
-        assert_equal expected, extract_mentions_or_lists_with_indices(input), description
-      end
-    end
-
-    def test_url_extractor_conformance
-      run_conformance_test(File.join(@conformance_dir, 'extract.yml'), :urls) do |description, expected, input|
-        assert_equal expected, extract_urls(input), description
-        expected.each do |expected_url|
-          assert_equal true, valid_url?(expected_url, true, false), "expected url [#{expected_url}] not valid"
-        end
-      end
-    end
-
-    def test_urls_with_indices_extractor_conformance
-      run_conformance_test(File.join(@conformance_dir, 'extract.yml'), :urls_with_indices) do |description, expected, input|
-        expected = expected.map{|elem| elem.inject({}){|h, (k,v)| h[k.to_sym] = v; h} }
-        assert_equal expected, extract_urls_with_indices(input), description
-      end
-    end
-
-    def test_hashtag_extractor_conformance
-      run_conformance_test(File.join(@conformance_dir, 'extract.yml'), :hashtags) do |description, expected, input|
-        assert_equal expected, extract_hashtags(input), description
-      end
-    end
-
-    def test_hashtags_with_indices_extractor_conformance
-      run_conformance_test(File.join(@conformance_dir, 'extract.yml'), :hashtags_with_indices) do |description, expected, input|
-        expected = expected.map{|elem| elem.inject({}){|h, (k,v)| h[k.to_sym] = v; h} }
-        assert_equal expected, extract_hashtags_with_indices(input), description
-      end
-    end
-  end
-  include ExtractorConformance
-
-  module AutolinkConformance
-    def test_users_autolink_conformance
-      run_conformance_test(File.join(@conformance_dir, 'autolink.yml'), :usernames) do |description, expected, input|
-        assert_equal expected, auto_link_usernames_or_lists(input, :suppress_no_follow => true), description
-      end
-    end
-
-    def test_lists_autolink_conformance
-      run_conformance_test(File.join(@conformance_dir, 'autolink.yml'), :lists) do |description, expected, input|
-        assert_equal expected, auto_link_usernames_or_lists(input, :suppress_no_follow => true), description
-      end
-    end
-
-    def test_urls_autolink_conformance
-      run_conformance_test(File.join(@conformance_dir, 'autolink.yml'), :urls) do |description, expected, input|
-        assert_equal expected, auto_link_urls_custom(input, :suppress_no_follow => true), description
-      end
-    end
-
-    def test_hashtags_autolink_conformance
-      run_conformance_test(File.join(@conformance_dir, 'autolink.yml'), :hashtags) do |description, expected, input|
-        assert_equal expected, auto_link_hashtags(input, :suppress_no_follow => true), description
-      end
-    end
-
-    def test_all_autolink_conformance
-      run_conformance_test(File.join(@conformance_dir, 'autolink.yml'), :all) do |description, expected, input|
-        assert_equal expected, auto_link(input, :suppress_no_follow => true), description
-      end
-    end
-  end
-  include AutolinkConformance
-
-  module HitHighlighterConformance
-
-    def test_plain_text_conformance
-      run_conformance_test(File.join(@conformance_dir, 'hit_highlighting.yml'), :plain_text, true) do |config|
-        assert_equal config['expected'], hit_highlight(config['text'], config['hits']), config['description']
-      end
-    end
-
-    def test_with_links_conformance
-      run_conformance_test(File.join(@conformance_dir, 'hit_highlighting.yml'), :with_links, true) do |config|
-        assert_equal config['expected'], hit_highlight(config['text'], config['hits']), config['description']
-      end
-    end
-  end
-  include HitHighlighterConformance
-
-  module ValidationConformance
-    def test_tweet_validation_conformance
-      run_conformance_test(File.join(@conformance_dir, 'validate.yml'), :tweets) do |description, expected, input|
-        assert_equal expected, valid_tweet_text?(input), description
-      end
-    end
-
-    def test_users_validation_conformance
-      run_conformance_test(File.join(@conformance_dir, 'validate.yml'), :usernames) do |description, expected, input|
-        assert_equal expected, valid_username?(input), description
-      end
-    end
-
-    def test_lists_validation_conformance
-      run_conformance_test(File.join(@conformance_dir, 'validate.yml'), :lists) do |description, expected, input|
-        assert_equal expected, valid_list?(input), description
-      end
-    end
-
-    def test_urls_validation_conformance
-      run_conformance_test(File.join(@conformance_dir, 'validate.yml'), :urls) do |description, expected, input|
-        assert_equal expected, valid_url?(input), description
-      end
-    end
-
-    def test_urls_without_protocol_validation_conformance
-      run_conformance_test(File.join(@conformance_dir, 'validate.yml'), :urls_without_protocol) do |description, expected, input|
-        assert_equal expected, valid_url?(input, true, false), description
-      end
-    end
-
-    def test_hashtags_validation_conformance
-      run_conformance_test(File.join(@conformance_dir, 'validate.yml'), :hashtags) do |description, expected, input|
-        assert_equal expected, valid_hashtag?(input), description
-      end
-    end
-  end
-  include ValidationConformance
-
   private
 
-  def run_conformance_test(file, test_type, hash_config = false, &block)
-    yaml = YAML.load_file(file)
-    assert yaml["tests"][test_type.to_s], "No such test suite: #{test_type.to_s}"
+  %w(description expected text hits).each do |key|
+    define_method key.to_sym do
+      @test_info[key]
+    end
+  end
+
+  CONFORMANCE_DIR = ENV['CONFORMANCE_DIR'] || File.expand_path("../twitter-text-conformance", __FILE__)
+
+  def self.def_conformance_test(file, test_type, &block)
+    yaml = YAML.load_file(File.join(CONFORMANCE_DIR, file))
+    raise  "No such test suite: #{test_type.to_s}" unless yaml["tests"][test_type.to_s]
 
     yaml["tests"][test_type.to_s].each do |test_info|
-      if hash_config
-        yield test_info
-      else
-        yield test_info['description'], test_info['expected'], test_info['text']
+      name = :"test_#{test_type}_#{test_info['description']}"
+      define_method name do
+        @test_info = test_info
+        instance_eval(&block)
       end
     end
+  end
+
+  public
+
+  # Extractor Conformance
+  def_conformance_test("extract.yml", :replies) do
+    assert_equal expected, extract_reply_screen_name(text), description
+  end
+
+  def_conformance_test("extract.yml", :mentions) do
+    assert_equal expected, extract_mentioned_screen_names(text), description
+  end
+
+  def_conformance_test("extract.yml", :mentions_with_indices) do
+    e = expected.map{|elem| elem.inject({}){|h, (k,v)| h[k.to_sym] = v; h} }
+    assert_equal e, extract_mentioned_screen_names_with_indices(text), description
+  end
+
+  def_conformance_test("extract.yml", :mentions_or_lists_with_indices) do
+    e = expected.map{|elem| elem.inject({}){|h, (k,v)| h[k.to_sym] = v; h} }
+    assert_equal e, extract_mentions_or_lists_with_indices(text), description
+  end
+
+  def_conformance_test("extract.yml", :urls) do
+    assert_equal expected, extract_urls(text), description
+    expected.each do |expected_url|
+      assert_equal true, valid_url?(expected_url, true, false), "expected url [#{expected_url}] not valid"
+    end
+  end
+
+  def_conformance_test("extract.yml", :urls_with_indices) do
+    e = expected.map{|elem| elem.inject({}){|h, (k,v)| h[k.to_sym] = v; h} }
+    assert_equal e, extract_urls_with_indices(text), description
+  end
+
+  def_conformance_test("extract.yml", :hashtags) do
+    assert_equal expected, extract_hashtags(text), description
+  end
+
+  def_conformance_test("extract.yml", :hashtags_with_indices) do
+    e = expected.map{|elem| elem.inject({}){|h, (k,v)| h[k.to_sym] = v; h} }
+    assert_equal e, extract_hashtags_with_indices(text), description
+  end
+
+  # Autolink Conformance
+  def_conformance_test("autolink.yml", :usernames) do
+    assert_equal expected, auto_link_usernames_or_lists(text, :suppress_no_follow => true), description
+  end
+
+  def_conformance_test("autolink.yml", :lists) do
+    assert_equal expected, auto_link_usernames_or_lists(text, :suppress_no_follow => true), description
+  end
+
+  def_conformance_test("autolink.yml", :urls) do
+    assert_equal expected, auto_link_urls_custom(text, :suppress_no_follow => true), description
+  end
+
+  def_conformance_test("autolink.yml", :hashtags) do
+    assert_equal expected, auto_link_hashtags(text, :suppress_no_follow => true), description
+  end
+
+  def_conformance_test("autolink.yml", :all) do
+    assert_equal expected, auto_link(text, :suppress_no_follow => true), description
+  end
+
+  # HitHighlighter Conformance
+  def_conformance_test("hit_highlighting.yml", :plain_text) do
+    assert_equal expected, hit_highlight(text, hits), description
+  end
+
+  def_conformance_test("hit_highlighting.yml", :with_links) do
+    assert_equal expected, hit_highlight(text, hits), description
+  end
+
+  # Validation Conformance
+  def_conformance_test("validate.yml", :tweets) do
+    assert_equal expected, valid_tweet_text?(text), description
+  end
+
+  def_conformance_test("validate.yml", :usernames) do
+    assert_equal expected, valid_username?(text), description
+  end
+
+  def_conformance_test("validate.yml", :lists) do
+    assert_equal expected, valid_list?(text), description
+  end
+
+  def_conformance_test("validate.yml", :urls) do
+    assert_equal expected, valid_url?(text), description
+  end
+
+  def_conformance_test("validate.yml", :urls_without_protocol) do
+    assert_equal expected, valid_url?(text, true, false), description
+  end
+
+  def_conformance_test("validate.yml", :hashtags) do
+    assert_equal expected, valid_hashtag?(text), description
   end
 end


### PR DESCRIPTION
Based on this https://github.com/twitter/twitter-text-rb/pull/34 request,
I've done more agressive refactoring and fixing some bugs.
This branch covers next changes:
- Refactoring `Twitter::Autolink`, `Rewriter` and `Extractor` aggressively.
- Due to this refactoring, it has really small behavior changes. I've also updated spec.
  - `url_class` for `auto_link_urls_custom` is ignored, please use class option instead.
- Add `Twitter::Deprecation` to deprecate some method which provides in `Autolink` and `Rewriter`.
  - Many methods in `Rewriter` and `auto_lnk_urls_custom` was deprecated.
- Improve conformance tests to run each test one by one so that we can run all tests in single run.
  - White testing, ignore order of tag attributes so that we can pass all conformance tests.
- Minor changes for Ruby 1.9 (also includes https://github.com/twitter/twitter-text-rb/pull/41 changes.)
