### PR TITLE
Fix for extracting domains without protocol starting with invalid character '$'

### DIFF
--- a/lib/regex.rb
+++ b/lib/regex.rb
@@ -168,7 +168,7 @@ module Twitter
     # URL related hash regex collection
     REGEXEN[:valid_preceding_chars] = /(?:[^-\/"'!=A-Z0-9_@＠\$#＃\.#{INVALID_CHARACTERS.join('')}]|^)/io
 
-    DOMAIN_VALID_CHARS = "[^[:punct:][:space:][:blank:][:cntrl:]#{INVALID_CHARACTERS.join('')}#{UNICODE_SPACES.join('')}]"
+    DOMAIN_VALID_CHARS = "[^\$[:punct:][:space:][:blank:][:cntrl:]#{INVALID_CHARACTERS.join('')}#{UNICODE_SPACES.join('')}]"
     REGEXEN[:valid_subdomain] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[_-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io
     REGEXEN[:valid_domain_name] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io
 


### PR DESCRIPTION
Hi,

Conformance tests were failing on ruby 1.9.2 and 1.9.3 with twitter-text-rb - specifically the case "DO NOT extract URL if preceded by $" when URIs don't include the protocol. I'm attaching a simple fix for this issue by filtering out $ from valid domain characters. 

If there is no special reason I am not aware of, it might be worth extending this list with other invalid characters like ^, as test cases like

```
    - description: "DO NOT extract URL if preceded by ^"
      text: "http://^twitter.com ^twitter.com"
      expected: []
```

are currently also failing for both with and without protocol (this one on both 1.8.7 and 1.9.2/1.9.3).

Thanks,
Zaki
