### PR TITLE
Modify extractHashtagsWithIndices() to not extract a hashtag if it's a part of URL.

### DIFF
--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -274,11 +274,14 @@ module Twitter
 
       if options[:check_url_overlap]
         # extract URLs
-        tags = tags + extract_urls_with_indices(text);
-        # remove duplicates
-        tags = remove_overlapping_entities(tags)
-        # remove URL entities
-        tags.reject!{|entity| !entity[:hashtag] }
+        urls = extract_urls_with_indices(text)
+        unless urls.empty?
+          tags.concat(urls)
+          # remove duplicates
+          tags = remove_overlapping_entities(tags)
+          # remove URL entities
+          tags.reject!{|entity| !entity[:hashtag] }
+        end
       end
 
       tags.each{|tag| yield tag[:hashtag], tag[:indices].first, tag[:indices].last} if block_given?

--- a/lib/extractor.rb
+++ b/lib/extractor.rb
@@ -47,6 +47,18 @@ module Twitter
   # A module for including Tweet parsing in a class. This module provides function for the extraction and processing
   # of usernames, lists, URLs and hashtags.
   module Extractor extend self
+    # Remove overlapping entities.
+    # This returns a new array with no overlapping entities.
+    def remove_overlapping_entities(entities)
+      # sort by start index
+      entities = entities.sort_by{|entity| entity[:indices].first}
+
+      # remove duplicates
+      prev = nil
+      entities.reject!{|entity| (prev && prev[:indices].last > entity[:indices].first) || (prev = entity) && false}
+      entities
+    end
+
     # Extracts all usernames, lists, hashtags and URLs  in the Tweet <tt>text</tt>
     # along with the indices for where the entity ocurred
     # If the <tt>text</tt> is <tt>nil</tt> or contains no entity an empty array
@@ -56,17 +68,12 @@ module Twitter
     def extract_entities_with_indices(text, options = {}, &block)
       # extract all entities
       entities = extract_urls_with_indices(text, options) +
-                 extract_hashtags_with_indices(text) +
+                 extract_hashtags_with_indices(text, :check_url_overlap => false) +
                  extract_mentions_or_lists_with_indices(text)
 
       return [] if entities.empty?
 
-      # sort by start index
-      entities = entities.sort_by{|entity| entity[:indices].first}
-
-      # remove duplicates
-      prev = nil
-      entities.reject!{|entity| (prev && prev[:indices].last > entity[:indices].first) || (prev = entity) && false}
+      entities = remove_overlapping_entities(entities)
 
       entities.each(&block) if block_given?
       entities
@@ -248,7 +255,7 @@ module Twitter
     # character.
     #
     # If a block is given then it will be called for each hashtag.
-    def extract_hashtags_with_indices(text) # :yields: hashtag_text, start, end
+    def extract_hashtags_with_indices(text, options = {:check_url_overlap => true}) # :yields: hashtag_text, start, end
       return [] unless text =~ /[#＃]/
 
       tags = []
@@ -264,6 +271,16 @@ module Twitter
           }
         end
       end
+
+      if options[:check_url_overlap]
+        # extract URLs
+        tags = tags + extract_urls_with_indices(text);
+        # remove duplicates
+        tags = remove_overlapping_entities(tags)
+        # remove URL entities
+        tags.reject!{|entity| !entity[:hashtag] }
+      end
+
       tags.each{|tag| yield tag[:hashtag], tag[:indices].first, tag[:indices].last} if block_given?
       tags
     end

--- a/test/conformance_test.rb
+++ b/test/conformance_test.rb
@@ -112,7 +112,7 @@ class ConformanceTest < Test::Unit::TestCase
   end
 
   def_conformance_test("autolink.yml", :urls) do
-    assert_equal_without_attribute_order expected, auto_link_urls_custom(text, :suppress_no_follow => true), description
+    assert_equal_without_attribute_order expected, auto_link_urls(text, :suppress_no_follow => true), description
   end
 
   def_conformance_test("autolink.yml", :hashtags) do


### PR DESCRIPTION
The current extractHashtagsWithIndices() extracts hashtags which are part of URL. E.g., it extracts "#hashtag" from "http://twitter.com/#hashtag".

This fixes the bug by adding an option in extractHashtagsWithIndices() called checkUrlOverlap. If it's set as true (which is a default value), extractHashtagsWithIndices() checks if any extracted hashtag overlaps with any URL in the text, and removes overlapping one.
