### PR TITLE
Modify linkToUrl() to use display_url and expanded_url in the input entity.

### DIFF
--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -163,7 +163,8 @@ module Twitter
 
     def url_entities_hash(url_entities)
       (url_entities || {}).inject({}) do |entities, entity|
-        entities[entity["url"]] = entity
+        entity = entity.symbolize_keys
+        entities[entity[:url]] = entity
         entities
       end
     end
@@ -183,12 +184,11 @@ module Twitter
 
       url_entities = url_entities_hash(options[:url_entities])
 
-      link_text = if entity[:display_url]
-        html_attrs[:title] ||= entity[:expanded_url]
-        link_text_with_display_expanded_urls(entity[:display_url], entity[:expanded_url])
-      elsif (url_entity = url_entities[url]) && url_entity["display_url"]
-        html_attrs[:title] ||= url_entity["expanded_url"]
-        link_text_with_display_expanded_urls(url_entity["display_url"], url_entity["expanded_url"])
+      # use entity from urlEntities if available
+      url_entity = url_entities[url] || entity
+      link_text = if url_entity[:display_url]
+        html_attrs[:title] ||= url_entity[:expanded_url]
+        link_text_with_entity(url_entity)
       else
         html_escape(url)
       end
@@ -198,7 +198,10 @@ module Twitter
 
     INVISIBLE_TAG_ATTRS = "style='font-size:0; line-height:0'".freeze
 
-    def link_text_with_display_expanded_urls(display_url, expanded_url)
+    def link_text_with_entity(entity)
+      display_url = entity[:display_url]
+      expanded_url = entity[:expanded_url]
+
       # Goal: If a user copies and pastes a tweet containing t.co'ed link, the resulting paste
       # should contain the full original URL (expanded_url), not the display URL.
       #

--- a/lib/autolink.rb
+++ b/lib/autolink.rb
@@ -183,9 +183,12 @@ module Twitter
 
       url_entities = url_entities_hash(options[:url_entities])
 
-      link_text = if (url_entity = url_entities[url]) && url_entity["display_url"]
+      link_text = if entity[:display_url]
+        html_attrs[:title] ||= entity[:expanded_url]
+        link_text_with_display_expanded_urls(entity[:display_url], entity[:expanded_url])
+      elsif (url_entity = url_entities[url]) && url_entity["display_url"]
         html_attrs[:title] ||= url_entity["expanded_url"]
-        link_text_with_entity(url_entity)
+        link_text_with_display_expanded_urls(url_entity["display_url"], url_entity["expanded_url"])
       else
         html_escape(url)
       end
@@ -195,10 +198,7 @@ module Twitter
 
     INVISIBLE_TAG_ATTRS = "style='font-size:0; line-height:0'".freeze
 
-    def link_text_with_entity(url_entity)
-      display_url  = url_entity["display_url"]
-      expanded_url = url_entity["expanded_url"]
-
+    def link_text_with_display_expanded_urls(display_url, expanded_url)
       # Goal: If a user copies and pastes a tweet containing t.co'ed link, the resulting paste
       # should contain the full original URL (expanded_url), not the display URL.
       #

--- a/lib/twitter-text.rb
+++ b/lib/twitter-text.rb
@@ -10,6 +10,7 @@ end
 
 require 'active_support'
 require 'active_support/core_ext/string/multibyte.rb'
+require 'active_support/core_ext/hash/keys.rb'
 
 %w(
   deprecation

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -665,6 +665,48 @@ describe Twitter::Autolink do
     end
   end
 
+  describe "link_text_with_entity" do
+    before do
+      @linker = TestAutolink.new
+    end
+
+    it "should use display_url and expanded_url" do
+      @linker.send(:link_text_with_entity,
+        {
+          :url => "http://t.co/abcde",
+          :display_url => "twitter.com",
+          :expanded_url => "http://twitter.com/"},
+        {:invisible_tag_attrs => "class='invisible'"}).gsub('"', "'").should == "<span class='tco-ellipsis'><span class='invisible'>&nbsp;</span></span><span class='invisible'>http://</span><span class='js-display-url'>twitter.com</span><span class='invisible'>/</span><span class='tco-ellipsis'><span class='invisible'>&nbsp;</span></span>";
+    end
+
+    it "should correctly handle display_url ending with '…'" do
+      @linker.send(:link_text_with_entity,
+        {
+          :url => "http://t.co/abcde",
+          :display_url => "twitter.com…",
+          :expanded_url => "http://twitter.com/abcdefg"},
+        {:invisible_tag_attrs => "class='invisible'"}).gsub('"', "'").should == "<span class='tco-ellipsis'><span class='invisible'>&nbsp;</span></span><span class='invisible'>http://</span><span class='js-display-url'>twitter.com</span><span class='invisible'>/abcdefg</span><span class='tco-ellipsis'><span class='invisible'>&nbsp;</span>…</span>";
+    end
+
+    it "should correctly handle display_url starting with '…'" do
+      @linker.send(:link_text_with_entity,
+        {
+          :url => "http://t.co/abcde",
+          :display_url => "…tter.com/abcdefg",
+          :expanded_url => "http://twitter.com/abcdefg"},
+        {:invisible_tag_attrs => "class='invisible'"}).gsub('"', "'").should == "<span class='tco-ellipsis'>…<span class='invisible'>&nbsp;</span></span><span class='invisible'>http://twi</span><span class='js-display-url'>tter.com/abcdefg</span><span class='invisible'></span><span class='tco-ellipsis'><span class='invisible'>&nbsp;</span></span>";
+    end
+
+    it "should not create spans if display_url and expanded_url are on different domains" do
+      @linker.send(:link_text_with_entity,
+        {
+          :url => "http://t.co/abcde",
+          :display_url => "pic.twitter.com/xyz",
+          :expanded_url => "http://twitter.com/foo/statuses/123/photo/1"},
+        {:invisible_tag_attrs => "class='invisible'"}).gsub('"', "'").should == "pic.twitter.com/xyz"
+    end
+  end
+
   describe "html_escape" do
     before do
       @linker = TestAutolink.new

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -569,6 +569,22 @@ describe Twitter::Autolink do
       html.inner_text.should == " http://blog.twitter.com/2011/05/twitter-for-mac-update.html …"
     end
 
+    it "should show display_url if available in entity" do
+      linked = TestAutolink.new.auto_link_entities("http://t.co/0JG5Mcq",
+        [{
+          :url => "http://t.co/0JG5Mcq",
+          :display_url => "blog.twitter.com/2011/05/twitte…",
+          :expanded_url => "http://blog.twitter.com/2011/05/twitter-for-mac-update.html",
+          :indices => [0, 19]
+        }]
+      )
+      html = Nokogiri::HTML(linked)
+      html.search('a').should_not be_empty
+      html.search('a[@href="http://t.co/0JG5Mcq"]').should_not be_empty
+      html.search('span[@class=js-display-url]').inner_text.should == "blog.twitter.com/2011/05/twitte"
+      html.inner_text.should == " http://blog.twitter.com/2011/05/twitter-for-mac-update.html …"
+    end
+
     it "should apply :class as a CSS class" do
       linked = TestAutolink.new.auto_link("http://example.com/", :class => 'myclass')
       linked.should have_autolinked_url('http://example.com/')


### PR DESCRIPTION
This modifies link_to_url() to use display_url and expanded_url if they are available in the input entity.

This still uses options.urlEntities if provided.
