### PR TITLE
Modify tweet_length to count URL as 20/21 chars

### DIFF
--- a/test/conformance_test.rb
+++ b/test/conformance_test.rb
@@ -156,4 +156,8 @@ class ConformanceTest < Test::Unit::TestCase
   def_conformance_test("validate.yml", :hashtags) do
     assert_equal expected, valid_hashtag?(text), description
   end
+
+  def_conformance_test("validate.yml", :lengths) do
+    assert_equal expected, tweet_length(text), description
+  end
 end


### PR DESCRIPTION
This is modifying Validator.tweet_length() to detect URL and count its length as either 20 (for HTTP or protocol-less URL) or 21 (for HTTPS URL).
