### PR TITLE
sort entities by index in rewrite_entities()

### DIFF
--- a/lib/twitter-text/rewriter.rb
+++ b/lib/twitter-text/rewriter.rb
@@ -4,6 +4,9 @@ module Twitter
     def rewrite_entities(text, entities)
       chars = text.to_s.to_char_a
 
+      # sort by start index
+      entities = entities.sort_by{|entity| entity[:indices].first}
+
       result = []
       last_index = entities.inject(0) do |last_index, entity|
         result << chars[last_index...entity[:indices].first]


### PR DESCRIPTION
One conformance test is failing because entities from auto_link_with_json() are not sorted by start index.

This will modify Rewriter.rewrite_entities() (which is used by auto_link_with_json() to sort entities by start index.
