### PR TITLE
Modify HitHighlighter to work w/o ActiveSupport

### DIFF
--- a/lib/twitter-text/hit_highlighter.rb
+++ b/lib/twitter-text/hit_highlighter.rb
@@ -23,9 +23,9 @@ module Twitter
 
       chunks = text.split(/[<>]/)
 
-      result = ""
+      result = []
       chunk_index, chunk = 0, chunks[0]
-      chunk_chars = chunk.respond_to?("mb_chars") ? chunk.mb_chars : chunk.respond_to?("chars") && chunk.chars.respond_to?("[]") ? chunk.chars : chunk
+      chunk_chars = chunk.to_s.to_char_a
       prev_chunks_len = 0
       chunk_cursor = 0
       start_in_chunk = false
@@ -49,13 +49,13 @@ module Twitter
           chunk_cursor = 0
           chunk_index += 2
           chunk = chunks[chunk_index]
-          chunk_chars = chunk.respond_to?("mb_chars") ? chunk.mb_chars : chunk.respond_to?("chars") && chunk.chars.respond_to?("[]") ? chunk.chars : chunk
+          chunk_chars = chunk.to_s.to_char_a
           start_in_chunk = false
         end
 
         if !placed && !chunk.nil?
           hit_spot = hit - prev_chunks_len
-          result << chunk_chars[chunk_cursor...hit_spot].to_s + tag
+          result << chunk_chars[chunk_cursor...hit_spot] << tag
           chunk_cursor = hit_spot
           if index % 2 == 0
             start_in_chunk = true
@@ -80,9 +80,7 @@ module Twitter
         end
       end
 
-      result
-    rescue
-      text
+      result.flatten.join
     end
   end
 end


### PR DESCRIPTION
HitHighlighter uses String.mb_chars() method in ActiveSupport, so if ActiveSupport is removed from the dependency (as in https://github.com/twitter/twitter-text-rb/pull/67) HitHighlighter won't work correctly for Unicode text on ruby 1.8.

This modifies HitHighlighter to work correctly on Unicode text on ruby 1.8 by using the same technique used in rewriter.rb.
