### PR TITLE
Add new options to Autolink

### DIFF
--- a/lib/twitter-text/autolink.rb
+++ b/lib/twitter-text/autolink.rb
@@ -6,16 +6,14 @@ module Twitter
   # A module for including Tweet auto-linking in a class. The primary use of this is for helpers/views so they can auto-link
   # usernames, lists, hashtags and URLs.
   module Autolink extend self
-    # Default CSS class for auto-linked URLs
-    DEFAULT_URL_CLASS = "tweet-url".freeze
-    # Default CSS class for auto-linked lists (along with the url class)
-    DEFAULT_LIST_CLASS = "list-slug".freeze
-    # Default CSS class for auto-linked usernames (along with the url class)
-    DEFAULT_USERNAME_CLASS = "username".freeze
-    # Default CSS class for auto-linked hashtags (along with the url class)
-    DEFAULT_HASHTAG_CLASS = "hashtag".freeze
-    # Default CSS class for auto-linked cashtags (along with the url class)
-    DEFAULT_CASHTAG_CLASS = "cashtag".freeze
+    # Default CSS class for auto-linked lists
+    DEFAULT_LIST_CLASS = "tweet-url list-slug".freeze
+    # Default CSS class for auto-linked usernames
+    DEFAULT_USERNAME_CLASS = "tweet-url username".freeze
+    # Default CSS class for auto-linked hashtags
+    DEFAULT_HASHTAG_CLASS = "tweet-url hashtag".freeze
+    # Default CSS class for auto-linked cashtags
+    DEFAULT_CASHTAG_CLASS = "tweet-url cashtag".freeze
 
     # Default URL base for auto-linked usernames
     DEFAULT_USERNAME_URL_BASE = "https://twitter.com/".freeze
@@ -30,7 +28,6 @@ module Twitter
     DEFAULT_INVISIBLE_TAG_ATTRS = "style='position:absolute;left:-9999px;'".freeze
 
     DEFAULT_OPTIONS = {
-      :url_class      => DEFAULT_URL_CLASS,
       :list_class     => DEFAULT_LIST_CLASS,
       :username_class => DEFAULT_USERNAME_CLASS,
       :hashtag_class  => DEFAULT_HASHTAG_CLASS,
@@ -84,13 +81,15 @@ module Twitter
     # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
     # and place in the <tt><a></tt> tag.
     #
-    # <tt>:url_class</tt>::      class to add to all <tt><a></tt> tags
+    # <tt>:url_class</tt>::      class to add to url <tt><a></tt> tags
     # <tt>:list_class</tt>::     class to add to list <tt><a></tt> tags
     # <tt>:username_class</tt>:: class to add to username <tt><a></tt> tags
     # <tt>:hashtag_class</tt>::  class to add to hashtag <tt><a></tt> tags
+    # <tt>:cashtag_class</tt>::  class to add to cashtag <tt><a></tt> tags
     # <tt>:username_url_base</tt>::  the value for <tt>href</tt> attribute on username links. The <tt>@username</tt> (minus the <tt>@</tt>) will be appended at the end of this.
     # <tt>:list_url_base</tt>::      the value for <tt>href</tt> attribute on list links. The <tt>@username/list</tt> (minus the <tt>@</tt>) will be appended at the end of this.
     # <tt>:hashtag_url_base</tt>::   the value for <tt>href</tt> attribute on hashtag links. The <tt>#hashtag</tt> (minus the <tt>#</tt>) will be appended at the end of this.
+    # <tt>:cashtag_url_base</tt>::   the value for <tt>href</tt> attribute on cashtag links. The <tt>$cashtag</tt> (minus the <tt>$</tt>) will be appended at the end of this.
     # <tt>:invisible_tag_attrs</tt>::   HTML attribute to add to invisible span tags
     # <tt>:username_include_symbol</tt>:: place the <tt>@</tt> symbol within username and list links
     # <tt>:suppress_lists</tt>::          disable auto-linking to lists
@@ -104,7 +103,6 @@ module Twitter
     # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
     # and place in the <tt><a></tt> tag.
     #
-    # <tt>:url_class</tt>::      class to add to all <tt><a></tt> tags
     # <tt>:list_class</tt>::     class to add to list <tt><a></tt> tags
     # <tt>:username_class</tt>:: class to add to username <tt><a></tt> tags
     # <tt>:username_url_base</tt>:: the value for <tt>href</tt> attribute on username links. The <tt>@username</tt> (minus the <tt>@</tt>) will be appended at the end of this.
@@ -121,7 +119,6 @@ module Twitter
     # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
     # and place in the <tt><a></tt> tag.
     #
-    # <tt>:url_class</tt>::     class to add to all <tt><a></tt> tags
     # <tt>:hashtag_class</tt>:: class to add to hashtag <tt><a></tt> tags
     # <tt>:hashtag_url_base</tt>:: the value for <tt>href</tt> attribute. The hashtag text (minus the <tt>#</tt>) will be appended at the end of this.
     # <tt>:suppress_no_follow</tt>:: do not add <tt>rel="nofollow"</tt> to auto-linked items
@@ -134,7 +131,6 @@ module Twitter
     # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
     # and place in the <tt><a></tt> tag.
     #
-    # <tt>:url_class</tt>::     class to add to all <tt><a></tt> tags
     # <tt>:cashtag_class</tt>:: class to add to cashtag <tt><a></tt> tags
     # <tt>:cashtag_url_base</tt>:: the value for <tt>href</tt> attribute. The cashtag text (minus the <tt>$</tt>) will be appended at the end of this.
     # <tt>:suppress_no_follow</tt>:: do not add <tt>rel="nofollow"</tt> to auto-linked items
@@ -147,6 +143,7 @@ module Twitter
     # Also any elements in the <tt>options</tt> hash will be converted to HTML attributes
     # and place in the <tt><a></tt> tag.
     #
+    # <tt>:url_class</tt>::     class to add to url <tt><a></tt> tags
     # <tt>:invisible_tag_attrs</tt>::   HTML attribute to add to invisible span tags
     # <tt>:suppress_no_follow</tt>:: do not add <tt>rel="nofollow"</tt> to auto-linked items
     def auto_link_urls(text, options = {}, &block)
@@ -224,6 +221,7 @@ module Twitter
       # NOTE auto link to urls do not use any default values and options
       # like url_class but use suppress_no_follow.
       html_attrs = options[:html_attrs].dup
+      html_attrs[:class] = options[:url_class] if options.key?(:url_class)
 
       url_entities = url_entities_hash(options[:url_entities])
 
@@ -312,7 +310,7 @@ module Twitter
       end
 
       html_attrs = {
-        :class => "#{options[:url_class]} #{options[:hashtag_class]}",
+        :class => "#{options[:hashtag_class]}",
         # FIXME As our conformance test, hash in title should be half-width,
         # this should be bug of conformance data.
         :title => "##{hashtag}"
@@ -332,7 +330,7 @@ module Twitter
       end
 
       html_attrs = {
-        :class => "#{options[:url_class]} #{options[:cashtag_class]}",
+        :class => "#{options[:cashtag_class]}",
         :title => "$#{cashtag}"
       }.merge(options[:html_attrs])
 
@@ -362,14 +360,14 @@ module Twitter
         else
           "#{options[:list_url_base]}#{name}"
         end
-        html_attrs[:class] ||= "#{options[:url_class]} #{options[:list_class]}"
+        html_attrs[:class] ||= "#{options[:list_class]}"
       else
         href = if options[:username_url_block]
           options[:username_url_block].call(chunk)
         else
           "#{options[:username_url_base]}#{name}"
         end
-        html_attrs[:class] ||= "#{options[:url_class]} #{options[:username_class]}"
+        html_attrs[:class] ||= "#{options[:username_class]}"
       end
 
       "#{at}#{link_to_text(text, href, html_attrs)}"

--- a/lib/twitter-text/autolink.rb
+++ b/lib/twitter-text/autolink.rb
@@ -187,7 +187,8 @@ module Twitter
       :username_url_base, :list_url_base, :hashtag_url_base, :cashtag_url_base,
       :username_url_block, :list_url_block, :hashtag_url_block, :link_url_block,
       :username_include_symbol, :suppress_lists, :suppress_no_follow, :url_entities,
-      :invisible_tag_attrs, :symbol_tag, :text_with_symbol_tag, :url_target, :link_attribute_block
+      :invisible_tag_attrs, :symbol_tag, :text_with_symbol_tag, :url_target,
+      :link_attribute_block, :link_text_block
     ]).freeze
 
     def extract_html_attrs_from_options!(options)
@@ -382,6 +383,7 @@ module Twitter
     def link_to_text(entity, text, href, attributes = {}, options = {})
       attributes[:href] = href
       options[:link_attribute_block].call(entity, attributes) if options[:link_attribute_block]
+      text = options[:link_text_block].call(entity, text) if options[:link_text_block]
       %(<a#{tag_attrs(attributes)}>#{text}</a>)
     end
 

--- a/lib/twitter-text/autolink.rb
+++ b/lib/twitter-text/autolink.rb
@@ -94,6 +94,11 @@ module Twitter
     # <tt>:username_include_symbol</tt>:: place the <tt>@</tt> symbol within username and list links
     # <tt>:suppress_lists</tt>::          disable auto-linking to lists
     # <tt>:suppress_no_follow</tt>::      do not add <tt>rel="nofollow"</tt> to auto-linked items
+    # <tt>:symbol_tag</tt>::          tag to apply around symbol (@, #, $) in username / hashtag / cashtag links
+    # <tt>:text_with_symbol_tag</tt>::          tag to apply around text part in username / hashtag / cashtag links
+    # <tt>:url_target</tt>::     the value for <tt>target</tt> attribute on URL links.
+    # <tt>:link_attribute_block</tt>::     function to modify the attributes of a link based on the entity. called with |entity, attributes| params, and should modify the attributes hash.
+    # <tt>:link_text_block</tt>::     function to modify the text of a link based on the entity. called with |entity, text| params, and should return a modified text.
     def auto_link(text, options = {}, &block)
       auto_link_entities(text, Extractor.extract_entities_with_indices(text, :extract_url_without_protocol => false), options, &block)
     end
@@ -110,6 +115,10 @@ module Twitter
     # <tt>:username_include_symbol</tt>:: place the <tt>@</tt> symbol within username and list links
     # <tt>:suppress_lists</tt>::          disable auto-linking to lists
     # <tt>:suppress_no_follow</tt>::      do not add <tt>rel="nofollow"</tt> to auto-linked items
+    # <tt>:symbol_tag</tt>::          tag to apply around symbol (@, #, $) in username / hashtag / cashtag links
+    # <tt>:text_with_symbol_tag</tt>::          tag to apply around text part in username / hashtag / cashtag links
+    # <tt>:link_attribute_block</tt>::     function to modify the attributes of a link based on the entity. called with |entity, attributes| params, and should modify the attributes hash.
+    # <tt>:link_text_block</tt>::     function to modify the text of a link based on the entity. called with |entity, text| params, and should return a modified text.
     def auto_link_usernames_or_lists(text, options = {}, &block) # :yields: list_or_username
       auto_link_entities(text, Extractor.extract_mentions_or_lists_with_indices(text), options, &block)
     end
@@ -122,6 +131,10 @@ module Twitter
     # <tt>:hashtag_class</tt>:: class to add to hashtag <tt><a></tt> tags
     # <tt>:hashtag_url_base</tt>:: the value for <tt>href</tt> attribute. The hashtag text (minus the <tt>#</tt>) will be appended at the end of this.
     # <tt>:suppress_no_follow</tt>:: do not add <tt>rel="nofollow"</tt> to auto-linked items
+    # <tt>:symbol_tag</tt>::          tag to apply around symbol (@, #, $) in username / hashtag / cashtag links
+    # <tt>:text_with_symbol_tag</tt>::          tag to apply around text part in username / hashtag / cashtag links
+    # <tt>:link_attribute_block</tt>::     function to modify the attributes of a link based on the entity. called with |entity, attributes| params, and should modify the attributes hash.
+    # <tt>:link_text_block</tt>::     function to modify the text of a link based on the entity. called with |entity, text| params, and should return a modified text.
     def auto_link_hashtags(text, options = {}, &block)  # :yields: hashtag_text
       auto_link_entities(text, Extractor.extract_hashtags_with_indices(text), options, &block)
     end
@@ -134,6 +147,10 @@ module Twitter
     # <tt>:cashtag_class</tt>:: class to add to cashtag <tt><a></tt> tags
     # <tt>:cashtag_url_base</tt>:: the value for <tt>href</tt> attribute. The cashtag text (minus the <tt>$</tt>) will be appended at the end of this.
     # <tt>:suppress_no_follow</tt>:: do not add <tt>rel="nofollow"</tt> to auto-linked items
+    # <tt>:symbol_tag</tt>::          tag to apply around symbol (@, #, $) in username / hashtag / cashtag links
+    # <tt>:text_with_symbol_tag</tt>::          tag to apply around text part in username / hashtag / cashtag links
+    # <tt>:link_attribute_block</tt>::     function to modify the attributes of a link based on the entity. called with |entity, attributes| params, and should modify the attributes hash.
+    # <tt>:link_text_block</tt>::     function to modify the text of a link based on the entity. called with |entity, text| params, and should return a modified text.
     def auto_link_cashtags(text, options = {}, &block)  # :yields: cashtag_text
       auto_link_entities(text, Extractor.extract_cashtags_with_indices(text), options, &block)
     end
@@ -146,6 +163,11 @@ module Twitter
     # <tt>:url_class</tt>::     class to add to url <tt><a></tt> tags
     # <tt>:invisible_tag_attrs</tt>::   HTML attribute to add to invisible span tags
     # <tt>:suppress_no_follow</tt>:: do not add <tt>rel="nofollow"</tt> to auto-linked items
+    # <tt>:symbol_tag</tt>::          tag to apply around symbol (@, #, $) in username / hashtag / cashtag links
+    # <tt>:text_with_symbol_tag</tt>::          tag to apply around text part in username / hashtag / cashtag links
+    # <tt>:url_target</tt>::     the value for <tt>target</tt> attribute on URL links.
+    # <tt>:link_attribute_block</tt>::     function to modify the attributes of a link based on the entity. called with |entity, attributes| params, and should modify the attributes hash.
+    # <tt>:link_text_block</tt>::     function to modify the text of a link based on the entity. called with |entity, text| params, and should return a modified text.
     def auto_link_urls(text, options = {}, &block)
       auto_link_entities(text, Extractor.extract_urls_with_indices(text, :extract_url_without_protocol => false), options, &block)
     end

--- a/lib/twitter-text/autolink.rb
+++ b/lib/twitter-text/autolink.rb
@@ -187,7 +187,7 @@ module Twitter
       :username_url_base, :list_url_base, :hashtag_url_base, :cashtag_url_base,
       :username_url_block, :list_url_block, :hashtag_url_block, :link_url_block,
       :username_include_symbol, :suppress_lists, :suppress_no_follow, :url_entities,
-      :invisible_tag_attrs, :symbol_tag, :text_with_symbol_tag
+      :invisible_tag_attrs, :symbol_tag, :text_with_symbol_tag, :url_target
     ]).freeze
 
     def extract_html_attrs_from_options!(options)
@@ -222,6 +222,9 @@ module Twitter
       # like url_class but use suppress_no_follow.
       html_attrs = options[:html_attrs].dup
       html_attrs[:class] = options[:url_class] if options.key?(:url_class)
+
+      # add target attribute only if :url_target is specified
+      html_attrs[:target] = options[:url_target] if options.key?(:url_target)
 
       url_entities = url_entities_hash(options[:url_entities])
 

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -682,6 +682,16 @@ describe Twitter::Autolink do
       linked = @linker.auto_link("http://example.com/", :link_url_block => lambda{|a| "dummy"})
       linked.should have_autolinked_url('dummy', 'http://example.com/')
     end
+
+    it "should apply :url_target only to auto-linked URLs" do
+      auto_linked = @linker.auto_link("#hashtag @mention http://test.com/", {:url_target => '_blank'})
+      auto_linked.should have_autolinked_hashtag('#hashtag')
+      auto_linked.should link_to_screen_name('mention')
+      auto_linked.should have_autolinked_url('http://test.com/')
+      auto_linked.should_not match(/<a[^>]+hashtag[^>]+target[^>]+>/)
+      auto_linked.should_not match(/<a[^>]+username[^>]+target[^>]+>/)
+      auto_linked.should match(/<a[^>]+test.com[^>]+target=\"_blank\"[^>]*>/)
+    end
   end
 
   describe "link_text_with_entity" do
@@ -731,24 +741,24 @@ describe Twitter::Autolink do
       @linker = TestAutolink.new
     end
     it "should put :symbol_tag around symbol" do
-      @linker.auto_link("@mention", {:symbol_tag => 's', :username_include_symbol=>true}).should match /<s>@<\/s>mention/
-      @linker.auto_link("#hash", {:symbol_tag => 's'}).should match /<s>#<\/s>hash/
+      @linker.auto_link("@mention", {:symbol_tag => 's', :username_include_symbol=>true}).should match(/<s>@<\/s>mention/)
+      @linker.auto_link("#hash", {:symbol_tag => 's'}).should match(/<s>#<\/s>hash/)
       result = @linker.auto_link("@mention #hash $CASH", {:symbol_tag => 'b', :username_include_symbol=>true})
-      result.should match /<b>@<\/b>mention/
-      result.should match /<b>#<\/b>hash/
-      result.should match /<b>\$<\/b>CASH/
+      result.should match(/<b>@<\/b>mention/)
+      result.should match(/<b>#<\/b>hash/)
+      result.should match(/<b>\$<\/b>CASH/)
     end
     it "should put :text_with_symbol_tag around text" do
       result = @linker.auto_link("@mention #hash $CASH", {:text_with_symbol_tag => 'b'})
-      result.should match /<b>mention<\/b>/
-      result.should match /<b>hash<\/b>/
-      result.should match /<b>CASH<\/b>/
+      result.should match(/<b>mention<\/b>/)
+      result.should match(/<b>hash<\/b>/)
+      result.should match(/<b>CASH<\/b>/)
     end
     it "should put :symbol_tag around symbol and :text_with_symbol_tag around text" do
       result = @linker.auto_link("@mention #hash $CASH", {:symbol_tag => 's', :text_with_symbol_tag => 'b', :username_include_symbol=>true})
-      result.should match /<s>@<\/s><b>mention<\/b>/
-      result.should match /<s>#<\/s><b>hash<\/b>/
-      result.should match /<s>\$<\/s><b>CASH<\/b>/
+      result.should match(/<s>@<\/s><b>mention<\/b>/)
+      result.should match(/<s>#<\/s><b>hash<\/b>/)
+      result.should match(/<s>\$<\/s><b>CASH<\/b>/)
     end
   end
 

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -707,6 +707,32 @@ describe Twitter::Autolink do
     end
   end
 
+  describe "symbol_tag" do
+    before do
+      @linker = TestAutolink.new
+    end
+    it "should put :symbol_tag around symbol" do
+      @linker.auto_link("@mention", {:symbol_tag => 's', :username_include_symbol=>true}).should match /<s>@<\/s>mention/
+      @linker.auto_link("#hash", {:symbol_tag => 's'}).should match /<s>#<\/s>hash/
+      result = @linker.auto_link("@mention #hash $CASH", {:symbol_tag => 'b', :username_include_symbol=>true})
+      result.should match /<b>@<\/b>mention/
+      result.should match /<b>#<\/b>hash/
+      result.should match /<b>\$<\/b>CASH/
+    end
+    it "should put :text_with_symbol_tag around text" do
+      result = @linker.auto_link("@mention #hash $CASH", {:text_with_symbol_tag => 'b'})
+      result.should match /<b>mention<\/b>/
+      result.should match /<b>hash<\/b>/
+      result.should match /<b>CASH<\/b>/
+    end
+    it "should put :symbol_tag around symbol and :text_with_symbol_tag around text" do
+      result = @linker.auto_link("@mention #hash $CASH", {:symbol_tag => 's', :text_with_symbol_tag => 'b', :username_include_symbol=>true})
+      result.should match /<s>@<\/s><b>mention<\/b>/
+      result.should match /<s>#<\/s><b>hash<\/b>/
+      result.should match /<s>\$<\/s><b>CASH<\/b>/
+    end
+  end
+
   describe "html_escape" do
     before do
       @linker = TestAutolink.new

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -552,8 +552,12 @@ describe Twitter::Autolink do
   end
 
   describe "autolinking options" do
+    before do
+      @linker = TestAutolink.new
+    end
+
     it "should show display_url when :url_entities provided" do
-      linked = TestAutolink.new.auto_link("http://t.co/0JG5Mcq", :url_entities => [{
+      linked = @linker.auto_link("http://t.co/0JG5Mcq", :url_entities => [{
         "url" => "http://t.co/0JG5Mcq",
         "display_url" => "blog.twitter.com/2011/05/twitte…",
         "expanded_url" => "http://blog.twitter.com/2011/05/twitter-for-mac-update.html",
@@ -571,7 +575,7 @@ describe Twitter::Autolink do
     end
 
     it "should accept invisible_tag_attrs option" do
-      linked = TestAutolink.new.auto_link("http://t.co/0JG5Mcq",
+      linked = @linker.auto_link("http://t.co/0JG5Mcq",
         {
           :url_entities => [{
             "url" => "http://t.co/0JG5Mcq",
@@ -589,7 +593,7 @@ describe Twitter::Autolink do
     end
 
     it "should show display_url if available in entity" do
-      linked = TestAutolink.new.auto_link_entities("http://t.co/0JG5Mcq",
+      linked = @linker.auto_link_entities("http://t.co/0JG5Mcq",
         [{
           :url => "http://t.co/0JG5Mcq",
           :display_url => "blog.twitter.com/2011/05/twitte…",
@@ -605,62 +609,77 @@ describe Twitter::Autolink do
     end
 
     it "should apply :class as a CSS class" do
-      linked = TestAutolink.new.auto_link("http://example.com/", :class => 'myclass')
+      linked = @linker.auto_link("http://example.com/", :class => 'myclass')
       linked.should have_autolinked_url('http://example.com/')
       linked.should match(/myclass/)
     end
 
+    it "should apply :url_class only on URL" do
+      linked = @linker.auto_link("http://twitter.com")
+      linked.should have_autolinked_url('http://twitter.com')
+      linked.should_not match(/class/)
+
+      linked = @linker.auto_link("http://twitter.com", :url_class => 'testClass')
+      linked.should have_autolinked_url('http://twitter.com')
+      linked.should match(/class=\"testClass\"/)
+
+      linked = @linker.auto_link("#hash @tw", :url_class => 'testClass')
+      linked.should match(/class=\"tweet-url hashtag\"/)
+      linked.should match(/class=\"tweet-url username\"/)
+      linked.should_not match(/class=\"testClass\"/)
+    end
+
     it "should add rel=nofollow by default" do
-      linked = TestAutolink.new.auto_link("http://example.com/")
+      linked = @linker.auto_link("http://example.com/")
       linked.should have_autolinked_url('http://example.com/')
       linked.should match(/nofollow/)
     end
 
     it "should include the '@' symbol in a username when passed :username_include_symbol" do
-      linked = TestAutolink.new.auto_link("@user", :username_include_symbol => true)
+      linked = @linker.auto_link("@user", :username_include_symbol => true)
       linked.should link_to_screen_name('user', '@user')
     end
 
     it "should include the '@' symbol in a list when passed :username_include_symbol" do
-      linked = TestAutolink.new.auto_link("@user/list", :username_include_symbol => true)
+      linked = @linker.auto_link("@user/list", :username_include_symbol => true)
       linked.should link_to_list_path('user/list', '@user/list')
     end
 
     it "should not add rel=nofollow when passed :suppress_no_follow" do
-      linked = TestAutolink.new.auto_link("http://example.com/", :suppress_no_follow => true)
+      linked = @linker.auto_link("http://example.com/", :suppress_no_follow => true)
       linked.should have_autolinked_url('http://example.com/')
       linked.should_not match(/nofollow/)
     end
 
     it "should not add a target attribute by default" do
-      linked = TestAutolink.new.auto_link("http://example.com/")
+      linked = @linker.auto_link("http://example.com/")
       linked.should have_autolinked_url('http://example.com/')
       linked.should_not match(/target=/)
     end
 
     it "should respect the :target option" do
-      linked = TestAutolink.new.auto_link("http://example.com/", :target => 'mywindow')
+      linked = @linker.auto_link("http://example.com/", :target => 'mywindow')
       linked.should have_autolinked_url('http://example.com/')
       linked.should match(/target="mywindow"/)
     end
 
     it "should customize href by username_url_block option" do
-      linked = TestAutolink.new.auto_link("@test", :username_url_block => lambda{|a| "dummy"})
+      linked = @linker.auto_link("@test", :username_url_block => lambda{|a| "dummy"})
       linked.should have_autolinked_url('dummy', 'test')
     end
 
     it "should customize href by list_url_block option" do
-      linked = TestAutolink.new.auto_link("@test/list", :list_url_block => lambda{|a| "dummy"})
+      linked = @linker.auto_link("@test/list", :list_url_block => lambda{|a| "dummy"})
       linked.should have_autolinked_url('dummy', 'test/list')
     end
 
     it "should customize href by hashtag_url_block option" do
-      linked = TestAutolink.new.auto_link("#hashtag", :hashtag_url_block => lambda{|a| "dummy"})
+      linked = @linker.auto_link("#hashtag", :hashtag_url_block => lambda{|a| "dummy"})
       linked.should have_autolinked_url('dummy', '#hashtag')
     end
 
     it "should customize href by link_url_block option" do
-      linked = TestAutolink.new.auto_link("http://example.com/", :link_url_block => lambda{|a| "dummy"})
+      linked = @linker.auto_link("http://example.com/", :link_url_block => lambda{|a| "dummy"})
       linked.should have_autolinked_url('dummy', 'http://example.com/')
     end
   end

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -683,7 +683,7 @@ describe Twitter::Autolink do
       linked.should have_autolinked_url('dummy', 'http://example.com/')
     end
 
-    it "should customie HTML attributes by link_attribute_block" do
+    it "should modify link attributes by link_attribute_block" do
       linked = @linker.auto_link("#hash @mention",
         :link_attribute_block => lambda{|entity, attributes|
           attributes[:"dummy-hash-attr"] = "test" if entity[:hashtag]
@@ -692,7 +692,7 @@ describe Twitter::Autolink do
       linked.should match(/<a[^>]+hashtag[^>]+dummy-hash-attr=\"test\"[^>]+>/)
       linked.should_not match(/<a[^>]+username[^>]+dummy-hash-attr=\"test\"[^>]+>/)
       linked.should_not match(/link_attribute_block/i)
-      
+
       linked = @linker.auto_link("@mention http://twitter.com/",
         :link_attribute_block => lambda{|entity, attributes|
           attributes["dummy-url-attr"] = entity[:url] if entity[:url]

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -702,6 +702,25 @@ describe Twitter::Autolink do
       linked.should match(/<a[^>]+dummy-url-attr=\"http:\/\/twitter.com\/\"/)
     end
 
+    it "should modify link text by link_text_block" do
+      linked = @linker.auto_link("#hash @mention",
+        :link_text_block => lambda{|entity, text|
+          entity[:hashtag] ? "#replaced" : "pre_#{text}_post"
+        }
+      )
+      linked.should match(/<a[^>]+>#replaced<\/a>/)
+      linked.should match(/<a[^>]+>pre_mention_post<\/a>/)
+
+      linked = @linker.auto_link("#hash @mention", {
+        :link_text_block => lambda{|entity, text|
+          "pre_#{text}_post"
+        },
+        :symbol_tag => "s", :text_with_symbol_tag => "b", :username_include_symbol => true
+      })
+      linked.should match(/<a[^>]+>pre_<s>#<\/s><b>hash<\/b>_post<\/a>/)
+      linked.should match(/<a[^>]+>pre_<s>@<\/s><b>mention<\/b>_post<\/a>/)
+    end
+
     it "should apply :url_target only to auto-linked URLs" do
       auto_linked = @linker.auto_link("#hashtag @mention http://test.com/", {:url_target => '_blank'})
       auto_linked.should have_autolinked_hashtag('#hashtag')

--- a/test/conformance_test.rb
+++ b/test/conformance_test.rb
@@ -33,6 +33,7 @@ class ConformanceTest < Test::Unit::TestCase
   def equal_nodes?(expected, actual)
     return false unless expected.name == actual.name
     return false unless ordered_attributes(expected) == ordered_attributes(actual)
+    return false if expected.text? && actual.text? && !(expected.content= actual.content)
 
     expected.children.each_with_index do |child, index|
       return false unless equal_nodes?(child, actual.children[index])


### PR DESCRIPTION
This will add the following options to Autolink.
- symbol_tag: a tag to apply around symbol (#,@,$) in hashtag/username/list/cashtag links. 
- text_with_symbol_tag: a tag to apply around text part in hashtag/username/list/cashtag links.
- url_target: the value of target attribute in URL links
- link_attribute_block: a block/function to modify attributes of a link based on the entity.
- link_text_block: a block/function to modify text of a link based on the entity.

Examples:

```
  auto_link("#hash", :symbol_tag => "s") => "<a...><s>#</s>hash</a>"
  auto_link("#hash", :text_with_symbol_tag => "b") => "<a...>#<b>hash</b></a>"
  auto_link("#hash", :link_attribute_block => lambda{|entity, attributes|
     attributes["custom-attr"] = "some_value" if entity[:hashtag]
  }) => "<a.. custom-attr="some_value"...>#hash</a>"
  auto_link("#hash", :link_text_block => lambda{|entity, text|
     entity[:hashtag] ? "prefix"+text : text
  }) => "<a...>prefix#text</a>"
```

This will also change url_class option, which is currently applied to all links but will only be applied to URL links.
