### PR TITLE
Allow :cashtag_url_block option

### DIFF
--- a/lib/twitter-text/autolink.rb
+++ b/lib/twitter-text/autolink.rb
@@ -207,7 +207,7 @@ module Twitter
     OPTIONS_NOT_ATTRIBUTES = Set.new([
       :url_class, :list_class, :username_class, :hashtag_class, :cashtag_class,
       :username_url_base, :list_url_base, :hashtag_url_base, :cashtag_url_base,
-      :username_url_block, :list_url_block, :hashtag_url_block, :link_url_block,
+      :username_url_block, :list_url_block, :hashtag_url_block, :cashtag_url_block, :link_url_block,
       :username_include_symbol, :suppress_lists, :suppress_no_follow, :url_entities,
       :invisible_tag_attrs, :symbol_tag, :text_with_symbol_tag, :url_target,
       :link_attribute_block, :link_text_block

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -678,6 +678,11 @@ describe Twitter::Autolink do
       linked.should have_autolinked_url('dummy', '#hashtag')
     end
 
+    it "should customize href by cashtag_url_block option" do
+      linked = @linker.auto_link("$CASH", :cashtag_url_block => lambda{|a| "dummy"})
+      linked.should have_autolinked_url('dummy', '$CASH')
+    end
+
     it "should customize href by link_url_block option" do
       linked = @linker.auto_link("http://example.com/", :link_url_block => lambda{|a| "dummy"})
       linked.should have_autolinked_url('dummy', 'http://example.com/')


### PR DESCRIPTION
There was a small bug in the autolinker causing :cashtag_url_block to fail. Included a test and a fix.
