### PR TITLE
Update tco URL lengths

### DIFF
--- a/lib/twitter-text/validation.rb
+++ b/lib/twitter-text/validation.rb
@@ -3,8 +3,9 @@ module Twitter
     MAX_LENGTH = 140
 
     DEFAULT_TCO_URL_LENGTHS = {
-      :short_url_length => 20,
-      :short_url_length_https => 21
+      :short_url_length => 22,
+      :short_url_length_https => 23,
+      :characters_reserved_per_media => 22
     }.freeze
 
     # Returns the length of the string as it would be displayed. This is equivilent to the length of the Unicode NFC


### PR DESCRIPTION
This is to update the Twitter::Validation::DEFAULT_TCO_URL_LENGTHS constant to use the new values stated here (https://dev.twitter.com/blog/upcoming-tco-changes).
