### PR TITLE
Update unf dependency to ~> 0.1.0

### DIFF
--- a/twitter-text.gemspec
+++ b/twitter-text.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rdoc"
   s.add_development_dependency "rspec"
   s.add_development_dependency "simplecov"
-  s.add_runtime_dependency     "unf", "~> 0.0.5"
+  s.add_runtime_dependency     "unf", "~> 0.1.0"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
As far as I can tell, [the 0.1.0 release contains no actual code changes](https://github.com/knu/ruby-unf/compare/v0.0.5...v0.1.0) but I believe it's worth updating the dependency to allow future 0.1.x releases, which may include bugfixes.
