### PR TITLE
Update Mention regex to include att [Rr][tT] variations

### DIFF
--- a/lib/twitter-text/regex.rb
+++ b/lib/twitter-text/regex.rb
@@ -168,7 +168,7 @@ module Twitter
     # Used in Extractor for final filtering
     REGEXEN[:end_hashtag_match] = /\A(?:[#＃]|:\/\/)/o
 
-    REGEXEN[:valid_mention_preceding_chars] = /(?:[^a-zA-Z0-9_!#\$%&*@＠]|^|RT:?)/o
+    REGEXEN[:valid_mention_preceding_chars] = /(?:[^a-zA-Z0-9_!#\$%&*@＠]|^|[rR][tT]:?)/o
     REGEXEN[:at_signs] = /[@＠]/
     REGEXEN[:valid_mention_or_list] = /
       (#{REGEXEN[:valid_mention_preceding_chars]})  # $1: Preceeding character


### PR DESCRIPTION
This commit is actually based on a pull request for the conformance
suite.
https://github.com/twitter/twitter-text-conformance/pull/58
As shown there twitter actually recognizes a mention no matter
what variation of "RT/rt/Rt/rT" preceeds it.
This commit was done on the dime of Simply Measured simplymeasured.com
