### PR TITLE
Add .dev TLD to allowed gTLDs

### DIFF
--- a/lib/twitter-text/regex.rb
+++ b/lib/twitter-text/regex.rb
@@ -187,7 +187,7 @@ module Twitter
     REGEXEN[:valid_subdomain] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[_-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io
     REGEXEN[:valid_domain_name] = /(?:(?:#{DOMAIN_VALID_CHARS}(?:[-]|#{DOMAIN_VALID_CHARS})*)?#{DOMAIN_VALID_CHARS}\.)/io
 
-    REGEXEN[:valid_gTLD] = /(?:(?:aero|asia|biz|cat|com|coop|edu|gov|info|int|jobs|mil|mobi|museum|name|net|org|pro|tel|travel|xxx)(?=[^0-9a-z]|$))/i
+    REGEXEN[:valid_gTLD] = /(?:(?:aero|asia|biz|cat|com|coop|edu|gov|info|int|jobs|mil|mobi|museum|name|net|org|pro|tel|travel|xxx|dev)(?=[^0-9a-z]|$))/i
     REGEXEN[:valid_ccTLD] = %r{
       (?:
         (?:ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar|as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|


### PR DESCRIPTION
Hi everyone, 

this PR is more of a question than a PR. I'm using this library in Rails and access my app under `http://my_app.dev/` with the `.dev` toplevel domain. Doing so results in `twitter-text-rb` not recognizing text as a URL and thus e.g. counting the tweet length "incorrectly". How would you handle such a case, do you have a suggestions for locally whitelisting `.dev` domains?

Thanks in advance!

Best,
Thomas
