### PR TITLE
Autolink URLs with nested parentheses.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: ruby
 rvm:
   - 1.8.7
   - 1.9.3
+  - 2.0.0

--- a/lib/twitter-text/regex.rb
+++ b/lib/twitter-text/regex.rb
@@ -224,7 +224,7 @@ module Twitter
     # Allow URL paths to contain balanced parens
     #  1. Used in Wikipedia URLs like /Primer_(film)
     #  2. Used in IIS sessions like /S(dfd346)/
-    REGEXEN[:valid_url_balanced_parens] = /\(#{REGEXEN[:valid_general_url_path_chars]}+\)/io
+    REGEXEN[:valid_url_balanced_parens] = /\((?:#{REGEXEN[:valid_general_url_path_chars]}|[()])+\)/io
     # Valid end-of-path chracters (so /foo. does not gobble the period).
     #   1. Allow =&# for empty URL parameters and other URL-join artifacts
     REGEXEN[:valid_url_path_ending_chars] = /[a-z0-9=_#\/\+\-#{LATIN_ACCENTS}]|(?:#{REGEXEN[:valid_url_balanced_parens]})/io

--- a/lib/twitter-text/regex.rb
+++ b/lib/twitter-text/regex.rb
@@ -221,10 +221,26 @@ module Twitter
     REGEXEN[:valid_port_number] = /[0-9]+/
 
     REGEXEN[:valid_general_url_path_chars] = /[a-z0-9!\*';:=\+\,\.\$\/%#\[\]\-_~&|@#{LATIN_ACCENTS}]/io
-    # Allow URL paths to contain balanced parens
+    # Allow URL paths to contain up to two nested levels of balanced parens
     #  1. Used in Wikipedia URLs like /Primer_(film)
     #  2. Used in IIS sessions like /S(dfd346)/
-    REGEXEN[:valid_url_balanced_parens] = /\((?:#{REGEXEN[:valid_general_url_path_chars]}|[()])+\)/io
+    #  3. Used in Rdio URLs like /track/We_Up_(Album_Version_(Edited))/
+    REGEXEN[:valid_url_balanced_parens] = /
+      \(
+        (?:
+          #{REGEXEN[:valid_general_url_path_chars]}+
+          |
+          # allow one nested level of balanced parentheses
+          (?:
+            #{REGEXEN[:valid_general_url_path_chars]}*
+            \(
+              #{REGEXEN[:valid_general_url_path_chars]}+
+            \)
+            #{REGEXEN[:valid_general_url_path_chars]}*
+          )
+        )
+      \)
+    /iox
     # Valid end-of-path chracters (so /foo. does not gobble the period).
     #   1. Allow =&# for empty URL parameters and other URL-join artifacts
     REGEXEN[:valid_url_path_ending_chars] = /[a-z0-9=_#\/\+\-#{LATIN_ACCENTS}]|(?:#{REGEXEN[:valid_url_balanced_parens]})/io

--- a/test/conformance_test.rb
+++ b/test/conformance_test.rb
@@ -54,7 +54,7 @@ class ConformanceTest < Test::Unit::TestCase
     raise  "No such test suite: #{test_type.to_s}" unless yaml["tests"][test_type.to_s]
 
     yaml["tests"][test_type.to_s].each do |test_info|
-      name = :"test_#{test_type}_#{test_info['description']}"
+      name = :"test_#{test_type} #{test_info['description']}"
       define_method name do
         @test_info = test_info
         instance_eval(&block)

--- a/twitter-text.gemspec
+++ b/twitter-text.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.summary = "Twitter text handling library"
 
   s.add_development_dependency "multi_json", "~> 1.3"
-  s.add_development_dependency "nokogiri"
+  s.add_development_dependency "nokogiri", "~> 1.5.10"
   s.add_development_dependency "rake"
   s.add_development_dependency "rdoc"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
Passes tests added in twitter/twitter-text-conformance#62. 

Doesn't check if the nested parentheses are balanced, but at least ensures that the opening parenthesis has a matching closing parenthesis. It's possible to check if all parentheses are balanced, but it requires either recursive regexes (not all languages support them) or extra non-regex logic. I think it's not worth it.
