### PR TITLE
Unfreeze the tweet's text before auto-linking it

### DIFF
--- a/lib/twitter-text/autolink.rb
+++ b/lib/twitter-text/autolink.rb
@@ -64,7 +64,7 @@ module Twitter
       options[:html_attrs] = extract_html_attrs_from_options!(options)
       options[:html_attrs][:rel] ||= "nofollow" unless options[:suppress_no_follow]
 
-      Twitter::Rewriter.rewrite_entities(text, entities) do |entity, chars|
+      Twitter::Rewriter.rewrite_entities(text.dup, entities) do |entity, chars|
         if entity[:url]
           link_to_url(entity, chars, options, &block)
         elsif entity[:hashtag]


### PR DESCRIPTION
A quickfix  for issue #101.
