### PR TITLE
Solution for #94: username link drops capitalisation

### DIFF
--- a/lib/twitter-text/autolink.rb
+++ b/lib/twitter-text/autolink.rb
@@ -370,8 +370,8 @@ module Twitter
 
     def link_to_screen_name(entity, chars, options = {})
       name  = "#{entity[:screen_name]}#{entity[:list_slug]}"
-      chunk = name
-      chunk = yield(name) if block_given?
+      chunk = name.dup
+      chunk = yield(chunk) if block_given?
       name.downcase!
 
       at = chars[entity[:indices].first]

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -23,6 +23,14 @@ describe Twitter::Autolink do
         end
       end
 
+      context "username in camelCase" do
+        def original_text() "@jaCob iS cOoL" end
+
+        it "should be linked" do
+          @autolinked_text.should link_to_screen_name('jaCob')
+        end
+      end
+
       context "username at beginning of line" do
         def original_text; "@jacob you're cool"; end
 


### PR DESCRIPTION
Because `name` and `chunk` can be references to the same object,
the destructive `name.downcase!` also affects `chunk`. This patch
ensures that the two are never the same object, and avoids the
unintended side-effect.
