### PR TITLE
Add target blank option to auto link

### DIFF
--- a/lib/twitter-text/autolink.rb
+++ b/lib/twitter-text/autolink.rb
@@ -99,6 +99,7 @@ module Twitter
     # <tt>:symbol_tag</tt>::          tag to apply around symbol (@, #, $) in username / hashtag / cashtag links
     # <tt>:text_with_symbol_tag</tt>::          tag to apply around text part in username / hashtag / cashtag links
     # <tt>:url_target</tt>::     the value for <tt>target</tt> attribute on URL links.
+    # <tt>:target_blank</tt>:: adds <tt>target="_blank"</tt> to all auto_linked items username / hashtag / cashtag links / urls
     # <tt>:link_attribute_block</tt>::     function to modify the attributes of a link based on the entity. called with |entity, attributes| params, and should modify the attributes hash.
     # <tt>:link_text_block</tt>::     function to modify the text of a link based on the entity. called with |entity, text| params, and should return a modified text.
     def auto_link(text, options = {}, &block)

--- a/lib/twitter-text/autolink.rb
+++ b/lib/twitter-text/autolink.rb
@@ -63,6 +63,7 @@ module Twitter
       options = DEFAULT_OPTIONS.merge(options)
       options[:html_attrs] = extract_html_attrs_from_options!(options)
       options[:html_attrs][:rel] ||= "nofollow" unless options[:suppress_no_follow]
+      options[:html_attrs][:target] = "_blank" if options[:target_blank] == true
 
       Twitter::Rewriter.rewrite_entities(text.dup, entities) do |entity, chars|
         if entity[:url]
@@ -210,7 +211,7 @@ module Twitter
       :username_url_base, :list_url_base, :hashtag_url_base, :cashtag_url_base,
       :username_url_block, :list_url_block, :hashtag_url_block, :cashtag_url_block, :link_url_block,
       :username_include_symbol, :suppress_lists, :suppress_no_follow, :url_entities,
-      :invisible_tag_attrs, :symbol_tag, :text_with_symbol_tag, :url_target,
+      :invisible_tag_attrs, :symbol_tag, :text_with_symbol_tag, :url_target, :target_blank,
       :link_attribute_block, :link_text_block
     ]).freeze
 

--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -742,6 +742,16 @@ describe Twitter::Autolink do
       auto_linked.should_not match(/<a[^>]+username[^>]+target[^>]+>/)
       auto_linked.should match(/<a[^>]+test.com[^>]+target=\"_blank\"[^>]*>/)
     end
+
+    it "should apply target='_blank' only to auto-linked URLs when :target_blank is set to true" do
+      auto_linked = @linker.auto_link("#hashtag @mention http://test.com/", {:target_blank => true})
+      auto_linked.should have_autolinked_hashtag('#hashtag')
+      auto_linked.should link_to_screen_name('mention')
+      auto_linked.should have_autolinked_url('http://test.com/')
+      auto_linked.should match(/<a[^>]+hashtag[^>]+target=\"_blank\"[^>]*>/)
+      auto_linked.should match(/<a[^>]+username[^>]+target=\"_blank\"[^>]*>/)
+      auto_linked.should match(/<a[^>]+test.com[^>]+target=\"_blank\"[^>]*>/)
+    end
   end
 
   describe "link_url_with_entity" do


### PR DESCRIPTION
Although `:target => "_blank"` is an available option I'm proposing adding `:target_blank => true` to keep in line with the js version of twitter text option of `targetBlank`. This will make it easier for developers to move back and forth between the two libraries without having to look up documentation. This new option adds `target="_blank"` to all auto linked entities not just url entities (as in `:url_target`).
