### PR TITLE
Fix conformance_test.rb to load libraries properly

### DIFF
--- a/test/conformance_test.rb
+++ b/test/conformance_test.rb
@@ -11,7 +11,8 @@ if OLD_RUBY
   $KCODE='u'
 end
 
-require File.expand_path('../../lib/twitter-text', __FILE__)
+$:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
+require 'twitter-text'
 
 class ConformanceTest < Test::Unit::TestCase
   include Twitter::Extractor


### PR DESCRIPTION
Previously the files installed into system is loaded if exists
