### PR TITLE
Convert (most) specs to RSpec 2.14.8 syntax using transpec. Skip custom matchers

### DIFF
--- a/spec/autolinking_spec.rb
+++ b/spec/autolinking_spec.rb
@@ -19,7 +19,7 @@ describe Twitter::Autolink do
         def original_text; "hello @jacob"; end
 
         it "should be linked" do
-          @autolinked_text.should link_to_screen_name('jacob')
+          expect(@autolinked_text).to link_to_screen_name('jacob')
         end
       end
 
@@ -27,7 +27,7 @@ describe Twitter::Autolink do
         def original_text() "@jaCob iS cOoL" end
 
         it "should be linked" do
-          @autolinked_text.should link_to_screen_name('jaCob')
+          expect(@autolinked_text).to link_to_screen_name('jaCob')
         end
       end
 
@@ -35,7 +35,7 @@ describe Twitter::Autolink do
         def original_text; "@jacob you're cool"; end
 
         it "should be linked" do
-          @autolinked_text.should link_to_screen_name('jacob')
+          expect(@autolinked_text).to link_to_screen_name('jacob')
         end
       end
 
@@ -43,7 +43,7 @@ describe Twitter::Autolink do
         def original_text; "meet@the beach"; end
 
         it "should not be linked" do
-          Nokogiri::HTML(@autolinked_text).search('a').should be_empty
+          expect(Nokogiri::HTML(@autolinked_text).search('a')).to be_empty
         end
       end
 
@@ -51,7 +51,7 @@ describe Twitter::Autolink do
         def original_text; "great.@jacob"; end
 
         it "should be linked" do
-          @autolinked_text.should link_to_screen_name('jacob')
+          expect(@autolinked_text).to link_to_screen_name('jacob')
         end
       end
 
@@ -59,7 +59,7 @@ describe Twitter::Autolink do
         def original_text; "@zach&^$%^"; end
 
         it "should not be linked" do
-          @autolinked_text.should link_to_screen_name('zach')
+          expect(@autolinked_text).to link_to_screen_name('zach')
         end
       end
 
@@ -70,7 +70,7 @@ describe Twitter::Autolink do
         end
 
         it "should not be linked" do
-          @autolinked_text.should link_to_screen_name(@twenty_character_username)
+          expect(@autolinked_text).to link_to_screen_name(@twenty_character_username)
         end
       end
 
@@ -78,7 +78,7 @@ describe Twitter::Autolink do
         def original_text; "@jacobの"; end
 
         it "should be linked" do
-          @autolinked_text.should link_to_screen_name('jacob')
+          expect(@autolinked_text).to link_to_screen_name('jacob')
         end
       end
 
@@ -86,7 +86,7 @@ describe Twitter::Autolink do
         def original_text; "あ@matz"; end
 
         it "should be linked" do
-          @autolinked_text.should link_to_screen_name('matz')
+          expect(@autolinked_text).to link_to_screen_name('matz')
         end
       end
 
@@ -94,7 +94,7 @@ describe Twitter::Autolink do
         def original_text; "あ@yoshimiの"; end
 
         it "should be linked" do
-          @autolinked_text.should link_to_screen_name('yoshimi')
+          expect(@autolinked_text).to link_to_screen_name('yoshimi')
         end
       end
 
@@ -104,7 +104,7 @@ describe Twitter::Autolink do
         end
 
         it "should be linked" do
-          @autolinked_text.should link_to_screen_name('jacob')
+          expect(@autolinked_text).to link_to_screen_name('jacob')
         end
       end
     end
@@ -114,8 +114,8 @@ describe Twitter::Autolink do
       context "when List is not available" do
         it "should not be linked" do
           @autolinked_text = TestAutolink.new.auto_link_usernames_or_lists("hello @jacob/my-list", :suppress_lists => true)
-          @autolinked_text.should_not link_to_list_path('jacob/my-list')
-          @autolinked_text.should include('my-list')
+          expect(@autolinked_text).not_to link_to_list_path('jacob/my-list')
+          expect(@autolinked_text).to include('my-list')
         end
       end
 
@@ -123,7 +123,7 @@ describe Twitter::Autolink do
         def original_text; "hello @jacob/my-list"; end
 
         it "should be linked" do
-          @autolinked_text.should link_to_list_path('jacob/my-list')
+          expect(@autolinked_text).to link_to_list_path('jacob/my-list')
         end
       end
 
@@ -131,8 +131,8 @@ describe Twitter::Autolink do
         def original_text; "hello @jacob/ my-list"; end
 
         it "should NOT be linked" do
-          @autolinked_text.should_not link_to_list_path('jacob/my-list')
-          @autolinked_text.should link_to_screen_name('jacob')
+          expect(@autolinked_text).not_to link_to_list_path('jacob/my-list')
+          expect(@autolinked_text).to link_to_screen_name('jacob')
         end
       end
 
@@ -140,7 +140,7 @@ describe Twitter::Autolink do
         def original_text; "hello @/my-list"; end
 
         it "should NOT be linked" do
-          Nokogiri::HTML(@autolinked_text).search('a').should be_empty
+          expect(Nokogiri::HTML(@autolinked_text).search('a')).to be_empty
         end
       end
 
@@ -148,7 +148,7 @@ describe Twitter::Autolink do
         def original_text; "@jacob/my-list"; end
 
         it "should be linked" do
-          @autolinked_text.should link_to_list_path('jacob/my-list')
+          expect(@autolinked_text).to link_to_list_path('jacob/my-list')
         end
       end
 
@@ -156,7 +156,7 @@ describe Twitter::Autolink do
         def original_text; "meet@the/beach"; end
 
         it "should not be linked" do
-          Nokogiri::HTML(@autolinked_text).search('a').should be_empty
+          expect(Nokogiri::HTML(@autolinked_text).search('a')).to be_empty
         end
       end
 
@@ -165,7 +165,7 @@ describe Twitter::Autolink do
 
         it "should be linked" do
           @autolinked_text = TestAutolink.new.auto_link("great.@jacob/my-list")
-          @autolinked_text.should link_to_list_path('jacob/my-list')
+          expect(@autolinked_text).to link_to_list_path('jacob/my-list')
         end
       end
 
@@ -173,7 +173,7 @@ describe Twitter::Autolink do
         def original_text; "@zach/test&^$%^"; end
 
         it "should be linked" do
-          @autolinked_text.should link_to_list_path('zach/test')
+          expect(@autolinked_text).to link_to_list_path('zach/test')
         end
       end
 
@@ -184,7 +184,7 @@ describe Twitter::Autolink do
         end
 
         it "should be linked" do
-          @autolinked_text.should link_to_list_path(@twentyfive_character_list)
+          expect(@autolinked_text).to link_to_list_path(@twentyfive_character_list)
         end
       end
     end
@@ -194,7 +194,7 @@ describe Twitter::Autolink do
         def original_text; "#123"; end
 
         it "should not be linked" do
-          @autolinked_text.should_not have_autolinked_hashtag('#123')
+          expect(@autolinked_text).not_to have_autolinked_hashtag('#123')
         end
       end
 
@@ -202,7 +202,7 @@ describe Twitter::Autolink do
         def original_text; "#ab1d"; end
 
         it "should be linked" do
-          @autolinked_text.should have_autolinked_hashtag('#ab1d')
+          expect(@autolinked_text).to have_autolinked_hashtag('#ab1d')
         end
       end
 
@@ -210,7 +210,7 @@ describe Twitter::Autolink do
         def original_text; "#a_b_c_d"; end
 
         it "should be linked" do
-          @autolinked_text.should have_autolinked_hashtag(original_text)
+          expect(@autolinked_text).to have_autolinked_hashtag(original_text)
         end
       end
 
@@ -218,7 +218,7 @@ describe Twitter::Autolink do
         def original_text; "ab#cd"; end
 
         it "should not be linked" do
-          @autolinked_text.should_not have_autolinked_hashtag(original_text)
+          expect(@autolinked_text).not_to have_autolinked_hashtag(original_text)
         end
       end
 
@@ -226,11 +226,11 @@ describe Twitter::Autolink do
         def original_text; "Here's my url: http://foobar.com/#home"; end
 
         it "should not link the hashtag" do
-          @autolinked_text.should_not have_autolinked_hashtag('#home')
+          expect(@autolinked_text).not_to have_autolinked_hashtag('#home')
         end
 
         it "should link the url" do
-          @autolinked_text.should have_autolinked_url('http://foobar.com/#home')
+          expect(@autolinked_text).to have_autolinked_url('http://foobar.com/#home')
         end
       end
 
@@ -238,7 +238,7 @@ describe Twitter::Autolink do
         def original_text; "#2ab"; end
 
         it "should be linked" do
-          @autolinked_text.should have_autolinked_hashtag(original_text)
+          expect(@autolinked_text).to have_autolinked_hashtag(original_text)
         end
       end
 
@@ -246,9 +246,9 @@ describe Twitter::Autolink do
         def original_text; "I'm frickin' awesome #ab #cd #ef"; end
 
         it "links each hashtag" do
-          @autolinked_text.should have_autolinked_hashtag('#ab')
-          @autolinked_text.should have_autolinked_hashtag('#cd')
-          @autolinked_text.should have_autolinked_hashtag('#ef')
+          expect(@autolinked_text).to have_autolinked_hashtag('#ab')
+          expect(@autolinked_text).to have_autolinked_hashtag('#cd')
+          expect(@autolinked_text).to have_autolinked_hashtag('#ef')
         end
       end
 
@@ -256,7 +256,7 @@ describe Twitter::Autolink do
         def original_text; "ok, great.#abc"; end
 
         it "should be linked" do
-          @autolinked_text.should have_autolinked_hashtag('#abc')
+          expect(@autolinked_text).to have_autolinked_hashtag('#abc')
         end
       end
 
@@ -264,7 +264,7 @@ describe Twitter::Autolink do
         def original_text; "&#nbsp;"; end
 
         it "should not be linked" do
-          @autolinked_text.should_not have_autolinked_hashtag('#nbsp;')
+          expect(@autolinked_text).not_to have_autolinked_hashtag('#nbsp;')
         end
       end
 
@@ -272,7 +272,7 @@ describe Twitter::Autolink do
         def original_text; "#great!"; end
 
         it "should be linked, but should not include the !" do
-          @autolinked_text.should have_autolinked_hashtag('#great')
+          expect(@autolinked_text).to have_autolinked_hashtag('#great')
         end
       end
 
@@ -280,7 +280,7 @@ describe Twitter::Autolink do
          def original_text; "#twj_devの"; end
 
         it "should be linked" do
-          @autolinked_text.should have_autolinked_hashtag('#twj_devの')
+          expect(@autolinked_text).to have_autolinked_hashtag('#twj_devの')
         end
       end
 
@@ -288,7 +288,7 @@ describe Twitter::Autolink do
         def original_text; "#{[0x3000].pack('U')}#twj_dev"; end
 
         it "should be linked" do
-          @autolinked_text.should have_autolinked_hashtag('#twj_dev')
+          expect(@autolinked_text).to have_autolinked_hashtag('#twj_dev')
         end
       end
 
@@ -296,7 +296,7 @@ describe Twitter::Autolink do
         def original_text; "#twj_dev#{[0x3000].pack('U')}"; end
 
         it "should be linked" do
-          @autolinked_text.should have_autolinked_hashtag('#twj_dev')
+          expect(@autolinked_text).to have_autolinked_hashtag('#twj_dev')
         end
       end
 
@@ -305,8 +305,8 @@ describe Twitter::Autolink do
 
         it "should be linked" do
           link = Nokogiri::HTML(@autolinked_text).search('a')
-          (link.inner_text.respond_to?(:force_encoding) ? link.inner_text.force_encoding("utf-8") : link.inner_text).should == "#{[0xFF03].pack('U')}twj_dev"
-          link.first['href'].should == 'https://twitter.com/#!/search?q=%23twj_dev'
+          expect(link.inner_text.respond_to?(:force_encoding) ? link.inner_text.force_encoding("utf-8") : link.inner_text).to eq("#{[0xFF03].pack('U')}twj_dev")
+          expect(link.first['href']).to eq('https://twitter.com/#!/search?q=%23twj_dev')
         end
       end
 
@@ -317,7 +317,7 @@ describe Twitter::Autolink do
         end
 
         it "should be linked" do
-          @autolinked_text.should == "<a class=\"tweet-url hashtag\" href=\"https://twitter.com/#!/search?q=%23éhashtag\" rel=\"nofollow\" title=\"#éhashtag\">#éhashtag</a>"
+          expect(@autolinked_text).to eq("<a class=\"tweet-url hashtag\" href=\"https://twitter.com/#!/search?q=%23éhashtag\" rel=\"nofollow\" title=\"#éhashtag\">#éhashtag</a>")
         end
       end
 
@@ -330,7 +330,7 @@ describe Twitter::Autolink do
         def original_text; "On my search engine #{url} I found good links."; end
 
         it "should be linked" do
-          @autolinked_text.should have_autolinked_url(url)
+          expect(@autolinked_text).to have_autolinked_url(url)
         end
       end
 
@@ -338,7 +338,7 @@ describe Twitter::Autolink do
         def original_text; "いまなにしてる#{url}いまなにしてる"; end
 
         it "should be linked" do
-          @autolinked_text.should have_autolinked_url(url)
+          expect(@autolinked_text).to have_autolinked_url(url)
         end
       end
 
@@ -346,14 +346,14 @@ describe Twitter::Autolink do
         def original_text; "I found a neatness (#{url})"; end
 
         it "should be linked" do
-          @autolinked_text.should have_autolinked_url(url)
+          expect(@autolinked_text).to have_autolinked_url(url)
         end
 
         context "when the URL ends with a slash;" do
           def url; "http://www.google.com/"; end
 
           it "should be linked" do
-            @autolinked_text.should have_autolinked_url(url)
+            expect(@autolinked_text).to have_autolinked_url(url)
           end
         end
 
@@ -361,7 +361,7 @@ describe Twitter::Autolink do
           def url; "http://www.google.com/fsdfasdf"; end
 
           it "should be linked" do
-            @autolinked_text.should have_autolinked_url(url)
+            expect(@autolinked_text).to have_autolinked_url(url)
           end
         end
       end
@@ -370,14 +370,14 @@ describe Twitter::Autolink do
         def original_text; "I found a neatness (#{url})"; end
 
         it "should be linked" do
-          @autolinked_text.should have_autolinked_url(url)
+          expect(@autolinked_text).to have_autolinked_url(url)
         end
 
         context "wikipedia" do
           def url; "http://en.wikipedia.org/wiki/Madonna_(artist)"; end
 
           it "should be linked" do
-            @autolinked_text.should have_autolinked_url(url)
+            expect(@autolinked_text).to have_autolinked_url(url)
           end
         end
 
@@ -385,7 +385,7 @@ describe Twitter::Autolink do
           def url; "http://msdn.com/S(deadbeef)/page.htm"; end
 
           it "should be linked" do
-            @autolinked_text.should have_autolinked_url(url)
+            expect(@autolinked_text).to have_autolinked_url(url)
           end
         end
 
@@ -393,7 +393,7 @@ describe Twitter::Autolink do
           def url; "http://example.com/i_has_a_("; end
 
           it "should be linked" do
-            @autolinked_text.should have_autolinked_url("http://example.com/i_has_a_")
+            expect(@autolinked_text).to have_autolinked_url("http://example.com/i_has_a_")
           end
         end
 
@@ -401,7 +401,7 @@ describe Twitter::Autolink do
           def url; "http://foo.com/foo_(\")_bar" end
 
           it "should be linked" do
-            @autolinked_text.should have_autolinked_url("http://foo.com/foo_")
+            expect(@autolinked_text).to have_autolinked_url("http://foo.com/foo_")
           end
         end
 
@@ -409,7 +409,7 @@ describe Twitter::Autolink do
           def url; 'http://x.xx.com/("style="color:red"onmouseover="alert(1)' end
 
           it "should be linked" do
-            @autolinked_text.should have_autolinked_url("http://x.xx.com/")
+            expect(@autolinked_text).to have_autolinked_url("http://x.xx.com/")
           end
         end
       end
@@ -418,7 +418,7 @@ describe Twitter::Autolink do
         def original_text; "Check this out @hoverbird:#{url}"; end
 
         it "should be linked" do
-          @autolinked_text.should have_autolinked_url(url)
+          expect(@autolinked_text).to have_autolinked_url(url)
         end
       end
 
@@ -426,7 +426,7 @@ describe Twitter::Autolink do
         it "does not consume ending punctuation" do
           matcher = TestAutolink.new
           %w| ? ! , . : ; ] ) } = \ ' |.each do |char|
-            matcher.auto_link("#{url}#{char}").should have_autolinked_url(url)
+            expect(matcher.auto_link("#{url}#{char}")).to have_autolinked_url(url)
           end
         end
       end
@@ -435,7 +435,7 @@ describe Twitter::Autolink do
         it "should be linked" do
           matcher = TestAutolink.new
           %w| \ ' / ! = |.each do |char|
-            matcher.auto_link("#{char}#{url}").should have_autolinked_url(url)
+            expect(matcher.auto_link("#{char}#{url}")).to have_autolinked_url(url)
           end
         end
       end
@@ -444,7 +444,7 @@ describe Twitter::Autolink do
         def original_text; "<link rel='true'>#{url}</link>"; end
 
         it "should be linked" do
-          @autolinked_text.should have_autolinked_url(url)
+          expect(@autolinked_text).to have_autolinked_url(url)
         end
       end
 
@@ -452,8 +452,8 @@ describe Twitter::Autolink do
         def original_text; "http://www.links.org link at start of page, link at end http://www.foo.org"; end
 
         it "should autolink each one" do
-          @autolinked_text.should have_autolinked_url('http://www.links.org')
-          @autolinked_text.should have_autolinked_url('http://www.foo.org')
+          expect(@autolinked_text).to have_autolinked_url('http://www.links.org')
+          expect(@autolinked_text).to have_autolinked_url('http://www.foo.org')
         end
       end
 
@@ -461,9 +461,9 @@ describe Twitter::Autolink do
         def original_text; "http://foo.com https://bar.com http://mail.foobar.org"; end
 
         it "should autolink each one, in the proper order" do
-          @autolinked_text.should have_autolinked_url('http://foo.com')
-          @autolinked_text.should have_autolinked_url('https://bar.com')
-          @autolinked_text.should have_autolinked_url('http://mail.foobar.org')
+          expect(@autolinked_text).to have_autolinked_url('http://foo.com')
+          expect(@autolinked_text).to have_autolinked_url('https://bar.com')
+          expect(@autolinked_text).to have_autolinked_url('http://mail.foobar.org')
         end
       end
 
@@ -471,7 +471,7 @@ describe Twitter::Autolink do
         def original_text; "Yahoo integriert Facebook http://golem.mobi/0912/71607.html"; end
 
         it "should autolink it" do
-          @autolinked_text.should have_autolinked_url('http://golem.mobi/0912/71607.html')
+          expect(@autolinked_text).to have_autolinked_url('http://golem.mobi/0912/71607.html')
         end
       end
 
@@ -480,7 +480,7 @@ describe Twitter::Autolink do
 
         it "does not link at all" do
           link = Nokogiri::HTML(@autolinked_text).search('a')
-          link.should be_empty
+          expect(link).to be_empty
         end
       end
 
@@ -489,7 +489,7 @@ describe Twitter::Autolink do
           def original_text; 'http://x.xx.com/@"style="color:pink"onmouseover=alert(1)//'; end
 
           it "should not allow XSS follwing @" do
-            @autolinked_text.should have_autolinked_url('http://x.xx.com/')
+            expect(@autolinked_text).to have_autolinked_url('http://x.xx.com/')
           end
         end
 
@@ -497,7 +497,7 @@ describe Twitter::Autolink do
           def original_text; 'http://example.com/@foobar'; end
 
           it "should link url" do
-            @autolinked_text.should have_autolinked_url('http://example.com/@foobar')
+            expect(@autolinked_text).to have_autolinked_url('http://example.com/@foobar')
           end
         end
 
@@ -505,8 +505,8 @@ describe Twitter::Autolink do
           def original_text; 'http://example.com/@foobar/'; end
 
           it "should not link the username but link full url" do
-            @autolinked_text.should have_autolinked_url('http://example.com/@foobar/')
-            @autolinked_text.should_not link_to_screen_name('foobar')
+            expect(@autolinked_text).to have_autolinked_url('http://example.com/@foobar/')
+            expect(@autolinked_text).not_to link_to_screen_name('foobar')
           end
         end
       end
@@ -516,7 +516,7 @@ describe Twitter::Autolink do
           def original_text; "Test a ton of periods http://example.com/path.........................................."; end
 
           it "should autolink" do
-            @autolinked_text.should have_autolinked_url('http://example.com/path')
+            expect(@autolinked_text).to have_autolinked_url('http://example.com/path')
           end
         end
 
@@ -524,7 +524,7 @@ describe Twitter::Autolink do
           def original_text; "Single char file ext http://www.bestbuy.com/site/Currie+Technologies+-+Ezip+400+Scooter/9885188.p?id=1218189013070&skuId=9885188"; end
 
           it "should autolink" do
-            @autolinked_text.should have_autolinked_url('http://www.bestbuy.com/site/Currie+Technologies+-+Ezip+400+Scooter/9885188.p?id=1218189013070&skuId=9885188')
+            expect(@autolinked_text).to have_autolinked_url('http://www.bestbuy.com/site/Currie+Technologies+-+Ezip+400+Scooter/9885188.p?id=1218189013070&skuId=9885188')
           end
         end
       end
@@ -538,21 +538,21 @@ describe Twitter::Autolink do
 
       it "should allow url/hashtag overlap" do
         auto_linked = @linker.auto_link("https://twitter.com/#search")
-        auto_linked.should have_autolinked_url('https://twitter.com/#search')
+        expect(auto_linked).to have_autolinked_url('https://twitter.com/#search')
       end
 
       it "should not add invalid option in HTML tags" do
         auto_linked = @linker.auto_link("https://twitter.com/ is a URL, not a hashtag", :hashtag_class => 'hashtag_classname')
-        auto_linked.should have_autolinked_url('https://twitter.com/')
-        auto_linked.should_not include('hashtag_class')
-        auto_linked.should_not include('hashtag_classname')
+        expect(auto_linked).to have_autolinked_url('https://twitter.com/')
+        expect(auto_linked).not_to include('hashtag_class')
+        expect(auto_linked).not_to include('hashtag_classname')
       end
 
       it "should autolink url/hashtag/mention in text with Unicode supplementary characters" do
         auto_linked = @linker.auto_link("#{[0x10400].pack('U')} #hashtag #{[0x10400].pack('U')} @mention #{[0x10400].pack('U')} http://twitter.com/")
-        auto_linked.should have_autolinked_hashtag('#hashtag')
-        auto_linked.should link_to_screen_name('mention')
-        auto_linked.should have_autolinked_url('http://twitter.com/')
+        expect(auto_linked).to have_autolinked_hashtag('#hashtag')
+        expect(auto_linked).to link_to_screen_name('mention')
+        expect(auto_linked).to have_autolinked_url('http://twitter.com/')
       end
     end
 
@@ -574,11 +574,11 @@ describe Twitter::Autolink do
         ]
       }])
       html = Nokogiri::HTML(linked)
-      html.search('a').should_not be_empty
-      html.search('a[@href="http://t.co/0JG5Mcq"]').should_not be_empty
-      html.search('span[@class=js-display-url]').inner_text.should == "blog.twitter.com/2011/05/twitte"
-      html.inner_text.should == " http://blog.twitter.com/2011/05/twitter-for-mac-update.html …"
-      html.search('span[@style="position:absolute;left:-9999px;"]').size.should == 4
+      expect(html.search('a')).not_to be_empty
+      expect(html.search('a[@href="http://t.co/0JG5Mcq"]')).not_to be_empty
+      expect(html.search('span[@class=js-display-url]').inner_text).to eq("blog.twitter.com/2011/05/twitte")
+      expect(html.inner_text).to eq(" http://blog.twitter.com/2011/05/twitter-for-mac-update.html …")
+      expect(html.search('span[@style="position:absolute;left:-9999px;"]').size).to eq(4)
     end
 
     it "should accept invisible_tag_attrs option" do
@@ -596,7 +596,7 @@ describe Twitter::Autolink do
           :invisible_tag_attrs => "style='dummy;'"
       })
       html = Nokogiri::HTML(linked)
-      html.search('span[@style="dummy;"]').size.should == 4
+      expect(html.search('span[@style="dummy;"]').size).to eq(4)
     end
 
     it "should show display_url if available in entity" do
@@ -609,90 +609,90 @@ describe Twitter::Autolink do
         }]
       )
       html = Nokogiri::HTML(linked)
-      html.search('a').should_not be_empty
-      html.search('a[@href="http://t.co/0JG5Mcq"]').should_not be_empty
-      html.search('span[@class=js-display-url]').inner_text.should == "blog.twitter.com/2011/05/twitte"
-      html.inner_text.should == " http://blog.twitter.com/2011/05/twitter-for-mac-update.html …"
+      expect(html.search('a')).not_to be_empty
+      expect(html.search('a[@href="http://t.co/0JG5Mcq"]')).not_to be_empty
+      expect(html.search('span[@class=js-display-url]').inner_text).to eq("blog.twitter.com/2011/05/twitte")
+      expect(html.inner_text).to eq(" http://blog.twitter.com/2011/05/twitter-for-mac-update.html …")
     end
 
     it "should apply :class as a CSS class" do
       linked = @linker.auto_link("http://example.com/", :class => 'myclass')
-      linked.should have_autolinked_url('http://example.com/')
-      linked.should match(/myclass/)
+      expect(linked).to have_autolinked_url('http://example.com/')
+      expect(linked).to match(/myclass/)
     end
 
     it "should apply :url_class only on URL" do
       linked = @linker.auto_link("http://twitter.com")
-      linked.should have_autolinked_url('http://twitter.com')
-      linked.should_not match(/class/)
+      expect(linked).to have_autolinked_url('http://twitter.com')
+      expect(linked).not_to match(/class/)
 
       linked = @linker.auto_link("http://twitter.com", :url_class => 'testClass')
-      linked.should have_autolinked_url('http://twitter.com')
-      linked.should match(/class=\"testClass\"/)
+      expect(linked).to have_autolinked_url('http://twitter.com')
+      expect(linked).to match(/class=\"testClass\"/)
 
       linked = @linker.auto_link("#hash @tw", :url_class => 'testClass')
-      linked.should match(/class=\"tweet-url hashtag\"/)
-      linked.should match(/class=\"tweet-url username\"/)
-      linked.should_not match(/class=\"testClass\"/)
+      expect(linked).to match(/class=\"tweet-url hashtag\"/)
+      expect(linked).to match(/class=\"tweet-url username\"/)
+      expect(linked).not_to match(/class=\"testClass\"/)
     end
 
     it "should add rel=nofollow by default" do
       linked = @linker.auto_link("http://example.com/")
-      linked.should have_autolinked_url('http://example.com/')
-      linked.should match(/nofollow/)
+      expect(linked).to have_autolinked_url('http://example.com/')
+      expect(linked).to match(/nofollow/)
     end
 
     it "should include the '@' symbol in a username when passed :username_include_symbol" do
       linked = @linker.auto_link("@user", :username_include_symbol => true)
-      linked.should link_to_screen_name('user', '@user')
+      expect(linked).to link_to_screen_name('user', '@user')
     end
 
     it "should include the '@' symbol in a list when passed :username_include_symbol" do
       linked = @linker.auto_link("@user/list", :username_include_symbol => true)
-      linked.should link_to_list_path('user/list', '@user/list')
+      expect(linked).to link_to_list_path('user/list', '@user/list')
     end
 
     it "should not add rel=nofollow when passed :suppress_no_follow" do
       linked = @linker.auto_link("http://example.com/", :suppress_no_follow => true)
-      linked.should have_autolinked_url('http://example.com/')
-      linked.should_not match(/nofollow/)
+      expect(linked).to have_autolinked_url('http://example.com/')
+      expect(linked).not_to match(/nofollow/)
     end
 
     it "should not add a target attribute by default" do
       linked = @linker.auto_link("http://example.com/")
-      linked.should have_autolinked_url('http://example.com/')
-      linked.should_not match(/target=/)
+      expect(linked).to have_autolinked_url('http://example.com/')
+      expect(linked).not_to match(/target=/)
     end
 
     it "should respect the :target option" do
       linked = @linker.auto_link("http://example.com/", :target => 'mywindow')
-      linked.should have_autolinked_url('http://example.com/')
-      linked.should match(/target="mywindow"/)
+      expect(linked).to have_autolinked_url('http://example.com/')
+      expect(linked).to match(/target="mywindow"/)
     end
 
     it "should customize href by username_url_block option" do
       linked = @linker.auto_link("@test", :username_url_block => lambda{|a| "dummy"})
-      linked.should have_autolinked_url('dummy', 'test')
+      expect(linked).to have_autolinked_url('dummy', 'test')
     end
 
     it "should customize href by list_url_block option" do
       linked = @linker.auto_link("@test/list", :list_url_block => lambda{|a| "dummy"})
-      linked.should have_autolinked_url('dummy', 'test/list')
+      expect(linked).to have_autolinked_url('dummy', 'test/list')
     end
 
     it "should customize href by hashtag_url_block option" do
       linked = @linker.auto_link("#hashtag", :hashtag_url_block => lambda{|a| "dummy"})
-      linked.should have_autolinked_url('dummy', '#hashtag')
+      expect(linked).to have_autolinked_url('dummy', '#hashtag')
     end
 
     it "should customize href by cashtag_url_block option" do
       linked = @linker.auto_link("$CASH", :cashtag_url_block => lambda{|a| "dummy"})
-      linked.should have_autolinked_url('dummy', '$CASH')
+      expect(linked).to have_autolinked_url('dummy', '$CASH')
     end
 
     it "should customize href by link_url_block option" do
       linked = @linker.auto_link("http://example.com/", :link_url_block => lambda{|a| "dummy"})
-      linked.should have_autolinked_url('dummy', 'http://example.com/')
+      expect(linked).to have_autolinked_url('dummy', 'http://example.com/')
     end
 
     it "should modify link attributes by link_attribute_block" do
@@ -701,17 +701,17 @@ describe Twitter::Autolink do
           attributes[:"dummy-hash-attr"] = "test" if entity[:hashtag]
         }
       )
-      linked.should match(/<a[^>]+hashtag[^>]+dummy-hash-attr=\"test\"[^>]+>/)
-      linked.should_not match(/<a[^>]+username[^>]+dummy-hash-attr=\"test\"[^>]+>/)
-      linked.should_not match(/link_attribute_block/i)
+      expect(linked).to match(/<a[^>]+hashtag[^>]+dummy-hash-attr=\"test\"[^>]+>/)
+      expect(linked).not_to match(/<a[^>]+username[^>]+dummy-hash-attr=\"test\"[^>]+>/)
+      expect(linked).not_to match(/link_attribute_block/i)
 
       linked = @linker.auto_link("@mention http://twitter.com/",
         :link_attribute_block => lambda{|entity, attributes|
           attributes["dummy-url-attr"] = entity[:url] if entity[:url]
         }
       )
-      linked.should_not match(/<a[^>]+username[^>]+dummy-url-attr=\"http:\/\/twitter.com\/\"[^>]*>/)
-      linked.should match(/<a[^>]+dummy-url-attr=\"http:\/\/twitter.com\/\"/)
+      expect(linked).not_to match(/<a[^>]+username[^>]+dummy-url-attr=\"http:\/\/twitter.com\/\"[^>]*>/)
+      expect(linked).to match(/<a[^>]+dummy-url-attr=\"http:\/\/twitter.com\/\"/)
     end
 
     it "should modify link text by link_text_block" do
@@ -720,8 +720,8 @@ describe Twitter::Autolink do
           entity[:hashtag] ? "#replaced" : "pre_#{text}_post"
         }
       )
-      linked.should match(/<a[^>]+>#replaced<\/a>/)
-      linked.should match(/<a[^>]+>pre_mention_post<\/a>/)
+      expect(linked).to match(/<a[^>]+>#replaced<\/a>/)
+      expect(linked).to match(/<a[^>]+>pre_mention_post<\/a>/)
 
       linked = @linker.auto_link("#hash @mention", {
         :link_text_block => lambda{|entity, text|
@@ -729,28 +729,28 @@ describe Twitter::Autolink do
         },
         :symbol_tag => "s", :text_with_symbol_tag => "b", :username_include_symbol => true
       })
-      linked.should match(/<a[^>]+>pre_<s>#<\/s><b>hash<\/b>_post<\/a>/)
-      linked.should match(/<a[^>]+>pre_<s>@<\/s><b>mention<\/b>_post<\/a>/)
+      expect(linked).to match(/<a[^>]+>pre_<s>#<\/s><b>hash<\/b>_post<\/a>/)
+      expect(linked).to match(/<a[^>]+>pre_<s>@<\/s><b>mention<\/b>_post<\/a>/)
     end
 
     it "should apply :url_target only to auto-linked URLs" do
       auto_linked = @linker.auto_link("#hashtag @mention http://test.com/", {:url_target => '_blank'})
-      auto_linked.should have_autolinked_hashtag('#hashtag')
-      auto_linked.should link_to_screen_name('mention')
-      auto_linked.should have_autolinked_url('http://test.com/')
-      auto_linked.should_not match(/<a[^>]+hashtag[^>]+target[^>]+>/)
-      auto_linked.should_not match(/<a[^>]+username[^>]+target[^>]+>/)
-      auto_linked.should match(/<a[^>]+test.com[^>]+target=\"_blank\"[^>]*>/)
+      expect(auto_linked).to have_autolinked_hashtag('#hashtag')
+      expect(auto_linked).to link_to_screen_name('mention')
+      expect(auto_linked).to have_autolinked_url('http://test.com/')
+      expect(auto_linked).not_to match(/<a[^>]+hashtag[^>]+target[^>]+>/)
+      expect(auto_linked).not_to match(/<a[^>]+username[^>]+target[^>]+>/)
+      expect(auto_linked).to match(/<a[^>]+test.com[^>]+target=\"_blank\"[^>]*>/)
     end
 
     it "should apply target='_blank' only to auto-linked URLs when :target_blank is set to true" do
       auto_linked = @linker.auto_link("#hashtag @mention http://test.com/", {:target_blank => true})
-      auto_linked.should have_autolinked_hashtag('#hashtag')
-      auto_linked.should link_to_screen_name('mention')
-      auto_linked.should have_autolinked_url('http://test.com/')
-      auto_linked.should match(/<a[^>]+hashtag[^>]+target=\"_blank\"[^>]*>/)
-      auto_linked.should match(/<a[^>]+username[^>]+target=\"_blank\"[^>]*>/)
-      auto_linked.should match(/<a[^>]+test.com[^>]+target=\"_blank\"[^>]*>/)
+      expect(auto_linked).to have_autolinked_hashtag('#hashtag')
+      expect(auto_linked).to link_to_screen_name('mention')
+      expect(auto_linked).to have_autolinked_url('http://test.com/')
+      expect(auto_linked).to match(/<a[^>]+hashtag[^>]+target=\"_blank\"[^>]*>/)
+      expect(auto_linked).to match(/<a[^>]+username[^>]+target=\"_blank\"[^>]*>/)
+      expect(auto_linked).to match(/<a[^>]+test.com[^>]+target=\"_blank\"[^>]*>/)
     end
   end
 
@@ -760,39 +760,39 @@ describe Twitter::Autolink do
     end
 
     it "should use display_url and expanded_url" do
-      @linker.send(:link_url_with_entity,
+      expect(@linker.send(:link_url_with_entity,
         {
           :url => "http://t.co/abcde",
           :display_url => "twitter.com",
           :expanded_url => "http://twitter.com/"},
-        {:invisible_tag_attrs => "class='invisible'"}).gsub('"', "'").should == "<span class='tco-ellipsis'><span class='invisible'>&nbsp;</span></span><span class='invisible'>http://</span><span class='js-display-url'>twitter.com</span><span class='invisible'>/</span><span class='tco-ellipsis'><span class='invisible'>&nbsp;</span></span>";
+        {:invisible_tag_attrs => "class='invisible'"}).gsub('"', "'")).to eq("<span class='tco-ellipsis'><span class='invisible'>&nbsp;</span></span><span class='invisible'>http://</span><span class='js-display-url'>twitter.com</span><span class='invisible'>/</span><span class='tco-ellipsis'><span class='invisible'>&nbsp;</span></span>");
     end
 
     it "should correctly handle display_url ending with '…'" do
-      @linker.send(:link_url_with_entity,
+      expect(@linker.send(:link_url_with_entity,
         {
           :url => "http://t.co/abcde",
           :display_url => "twitter.com…",
           :expanded_url => "http://twitter.com/abcdefg"},
-        {:invisible_tag_attrs => "class='invisible'"}).gsub('"', "'").should == "<span class='tco-ellipsis'><span class='invisible'>&nbsp;</span></span><span class='invisible'>http://</span><span class='js-display-url'>twitter.com</span><span class='invisible'>/abcdefg</span><span class='tco-ellipsis'><span class='invisible'>&nbsp;</span>…</span>";
+        {:invisible_tag_attrs => "class='invisible'"}).gsub('"', "'")).to eq("<span class='tco-ellipsis'><span class='invisible'>&nbsp;</span></span><span class='invisible'>http://</span><span class='js-display-url'>twitter.com</span><span class='invisible'>/abcdefg</span><span class='tco-ellipsis'><span class='invisible'>&nbsp;</span>…</span>");
     end
 
     it "should correctly handle display_url starting with '…'" do
-      @linker.send(:link_url_with_entity,
+      expect(@linker.send(:link_url_with_entity,
         {
           :url => "http://t.co/abcde",
           :display_url => "…tter.com/abcdefg",
           :expanded_url => "http://twitter.com/abcdefg"},
-        {:invisible_tag_attrs => "class='invisible'"}).gsub('"', "'").should == "<span class='tco-ellipsis'>…<span class='invisible'>&nbsp;</span></span><span class='invisible'>http://twi</span><span class='js-display-url'>tter.com/abcdefg</span><span class='invisible'></span><span class='tco-ellipsis'><span class='invisible'>&nbsp;</span></span>";
+        {:invisible_tag_attrs => "class='invisible'"}).gsub('"', "'")).to eq("<span class='tco-ellipsis'>…<span class='invisible'>&nbsp;</span></span><span class='invisible'>http://twi</span><span class='js-display-url'>tter.com/abcdefg</span><span class='invisible'></span><span class='tco-ellipsis'><span class='invisible'>&nbsp;</span></span>");
     end
 
     it "should not create spans if display_url and expanded_url are on different domains" do
-      @linker.send(:link_url_with_entity,
+      expect(@linker.send(:link_url_with_entity,
         {
           :url => "http://t.co/abcde",
           :display_url => "pic.twitter.com/xyz",
           :expanded_url => "http://twitter.com/foo/statuses/123/photo/1"},
-        {:invisible_tag_attrs => "class='invisible'"}).gsub('"', "'").should == "pic.twitter.com/xyz"
+        {:invisible_tag_attrs => "class='invisible'"}).gsub('"', "'")).to eq("pic.twitter.com/xyz")
     end
   end
 
@@ -801,24 +801,24 @@ describe Twitter::Autolink do
       @linker = TestAutolink.new
     end
     it "should put :symbol_tag around symbol" do
-      @linker.auto_link("@mention", {:symbol_tag => 's', :username_include_symbol=>true}).should match(/<s>@<\/s>mention/)
-      @linker.auto_link("#hash", {:symbol_tag => 's'}).should match(/<s>#<\/s>hash/)
+      expect(@linker.auto_link("@mention", {:symbol_tag => 's', :username_include_symbol=>true})).to match(/<s>@<\/s>mention/)
+      expect(@linker.auto_link("#hash", {:symbol_tag => 's'})).to match(/<s>#<\/s>hash/)
       result = @linker.auto_link("@mention #hash $CASH", {:symbol_tag => 'b', :username_include_symbol=>true})
-      result.should match(/<b>@<\/b>mention/)
-      result.should match(/<b>#<\/b>hash/)
-      result.should match(/<b>\$<\/b>CASH/)
+      expect(result).to match(/<b>@<\/b>mention/)
+      expect(result).to match(/<b>#<\/b>hash/)
+      expect(result).to match(/<b>\$<\/b>CASH/)
     end
     it "should put :text_with_symbol_tag around text" do
       result = @linker.auto_link("@mention #hash $CASH", {:text_with_symbol_tag => 'b'})
-      result.should match(/<b>mention<\/b>/)
-      result.should match(/<b>hash<\/b>/)
-      result.should match(/<b>CASH<\/b>/)
+      expect(result).to match(/<b>mention<\/b>/)
+      expect(result).to match(/<b>hash<\/b>/)
+      expect(result).to match(/<b>CASH<\/b>/)
     end
     it "should put :symbol_tag around symbol and :text_with_symbol_tag around text" do
       result = @linker.auto_link("@mention #hash $CASH", {:symbol_tag => 's', :text_with_symbol_tag => 'b', :username_include_symbol=>true})
-      result.should match(/<s>@<\/s><b>mention<\/b>/)
-      result.should match(/<s>#<\/s><b>hash<\/b>/)
-      result.should match(/<s>\$<\/s><b>CASH<\/b>/)
+      expect(result).to match(/<s>@<\/s><b>mention<\/b>/)
+      expect(result).to match(/<s>#<\/s><b>hash<\/b>/)
+      expect(result).to match(/<s>\$<\/s><b>CASH<\/b>/)
     end
   end
 
@@ -827,17 +827,17 @@ describe Twitter::Autolink do
       @linker = TestAutolink.new
     end
     it "should escape html entities properly" do
-      @linker.html_escape("&").should == "&amp;"
-      @linker.html_escape(">").should == "&gt;"
-      @linker.html_escape("<").should == "&lt;"
-      @linker.html_escape("\"").should == "&quot;"
-      @linker.html_escape("'").should == "&#39;"
-      @linker.html_escape("&<>\"").should == "&amp;&lt;&gt;&quot;"
-      @linker.html_escape("<div>").should == "&lt;div&gt;"
-      @linker.html_escape("a&b").should == "a&amp;b"
-      @linker.html_escape("<a href=\"https://twitter.com\" target=\"_blank\">twitter & friends</a>").should == "&lt;a href=&quot;https://twitter.com&quot; target=&quot;_blank&quot;&gt;twitter &amp; friends&lt;/a&gt;"
-      @linker.html_escape("&amp;").should == "&amp;amp;"
-      @linker.html_escape(nil).should == nil
+      expect(@linker.html_escape("&")).to eq("&amp;")
+      expect(@linker.html_escape(">")).to eq("&gt;")
+      expect(@linker.html_escape("<")).to eq("&lt;")
+      expect(@linker.html_escape("\"")).to eq("&quot;")
+      expect(@linker.html_escape("'")).to eq("&#39;")
+      expect(@linker.html_escape("&<>\"")).to eq("&amp;&lt;&gt;&quot;")
+      expect(@linker.html_escape("<div>")).to eq("&lt;div&gt;")
+      expect(@linker.html_escape("a&b")).to eq("a&amp;b")
+      expect(@linker.html_escape("<a href=\"https://twitter.com\" target=\"_blank\">twitter & friends</a>")).to eq("&lt;a href=&quot;https://twitter.com&quot; target=&quot;_blank&quot;&gt;twitter &amp; friends&lt;/a&gt;")
+      expect(@linker.html_escape("&amp;")).to eq("&amp;amp;")
+      expect(@linker.html_escape(nil)).to eq(nil)
     end
   end
 

--- a/spec/extractor_spec.rb
+++ b/spec/extractor_spec.rb
@@ -13,37 +13,37 @@ describe Twitter::Extractor do
   describe "mentions" do
     context "single screen name alone " do
       it "should be linked" do
-        @extractor.extract_mentioned_screen_names("@alice").should == ["alice"]
+        expect(@extractor.extract_mentioned_screen_names("@alice")).to eq(["alice"])
       end
 
       it "should be linked with _" do
-        @extractor.extract_mentioned_screen_names("@alice_adams").should == ["alice_adams"]
+        expect(@extractor.extract_mentioned_screen_names("@alice_adams")).to eq(["alice_adams"])
       end
 
       it "should be linked if numeric" do
-        @extractor.extract_mentioned_screen_names("@1234").should == ["1234"]
+        expect(@extractor.extract_mentioned_screen_names("@1234")).to eq(["1234"])
       end
     end
 
     context "multiple screen names" do
       it "should both be linked" do
-        @extractor.extract_mentioned_screen_names("@alice @bob").should == ["alice", "bob"]
+        expect(@extractor.extract_mentioned_screen_names("@alice @bob")).to eq(["alice", "bob"])
       end
     end
 
     context "screen names embedded in text" do
       it "should be linked in Latin text" do
-        @extractor.extract_mentioned_screen_names("waiting for @alice to arrive").should == ["alice"]
+        expect(@extractor.extract_mentioned_screen_names("waiting for @alice to arrive")).to eq(["alice"])
       end
 
       it "should be linked in Japanese text" do
-        @extractor.extract_mentioned_screen_names("の@aliceに到着を待っている").should == ["alice"]
+        expect(@extractor.extract_mentioned_screen_names("の@aliceに到着を待っている")).to eq(["alice"])
       end
 
       it "should ignore mentions preceded by !, @, #, $, %, & or *" do
         invalid_chars = ['!', '@', '#', '$', '%', '&', '*']
         invalid_chars.each do |c|
-          @extractor.extract_mentioned_screen_names("f#{c}@kn").should == []
+          expect(@extractor.extract_mentioned_screen_names("f#{c}@kn")).to eq([])
         end
       end
     end
@@ -51,49 +51,51 @@ describe Twitter::Extractor do
     it "should accept a block arugment and call it in order" do
       needed = ["alice", "bob"]
       @extractor.extract_mentioned_screen_names("@alice @bob") do |sn|
-        sn.should == needed.shift
+        expect(sn).to eq(needed.shift)
       end
-      needed.should == []
+      expect(needed).to eq([])
     end
   end
 
   describe "mentions with indices" do
     context "single screen name alone " do
       it "should be linked and the correct indices" do
-        @extractor.extract_mentioned_screen_names_with_indices("@alice").should == [{:screen_name => "alice", :indices => [0, 6]}]
+        expect(@extractor.extract_mentioned_screen_names_with_indices("@alice")).to eq([{:screen_name => "alice", :indices => [0, 6]}])
       end
 
       it "should be linked with _ and the correct indices" do
-        @extractor.extract_mentioned_screen_names_with_indices("@alice_adams").should == [{:screen_name => "alice_adams", :indices => [0, 12]}]
+        expect(@extractor.extract_mentioned_screen_names_with_indices("@alice_adams")).to eq([{:screen_name => "alice_adams", :indices => [0, 12]}])
       end
 
       it "should be linked if numeric and the correct indices" do
-        @extractor.extract_mentioned_screen_names_with_indices("@1234").should == [{:screen_name => "1234", :indices => [0, 5]}]
+        expect(@extractor.extract_mentioned_screen_names_with_indices("@1234")).to eq([{:screen_name => "1234", :indices => [0, 5]}])
       end
     end
 
     context "multiple screen names" do
       it "should both be linked with the correct indices" do
-        @extractor.extract_mentioned_screen_names_with_indices("@alice @bob").should ==
+        expect(@extractor.extract_mentioned_screen_names_with_indices("@alice @bob")).to eq(
           [{:screen_name => "alice", :indices => [0, 6]},
            {:screen_name => "bob", :indices => [7, 11]}]
+        )
       end
 
       it "should be linked with the correct indices even when repeated" do
-        @extractor.extract_mentioned_screen_names_with_indices("@alice @alice @bob").should ==
+        expect(@extractor.extract_mentioned_screen_names_with_indices("@alice @alice @bob")).to eq(
           [{:screen_name => "alice", :indices => [0, 6]},
            {:screen_name => "alice", :indices => [7, 13]},
            {:screen_name => "bob", :indices => [14, 18]}]
+        )
       end
     end
 
     context "screen names embedded in text" do
       it "should be linked in Latin text with the correct indices" do
-        @extractor.extract_mentioned_screen_names_with_indices("waiting for @alice to arrive").should == [{:screen_name => "alice", :indices => [12, 18]}]
+        expect(@extractor.extract_mentioned_screen_names_with_indices("waiting for @alice to arrive")).to eq([{:screen_name => "alice", :indices => [12, 18]}])
       end
 
       it "should be linked in Japanese text with the correct indices" do
-        @extractor.extract_mentioned_screen_names_with_indices("の@aliceに到着を待っている").should == [{:screen_name => "alice", :indices => [1, 7]}]
+        expect(@extractor.extract_mentioned_screen_names_with_indices("の@aliceに到着を待っている")).to eq([{:screen_name => "alice", :indices => [1, 7]}])
       end
     end
 
@@ -101,45 +103,45 @@ describe Twitter::Extractor do
       needed = [{:screen_name => "alice", :indices => [0, 6]}, {:screen_name => "bob", :indices => [7, 11]}]
       @extractor.extract_mentioned_screen_names_with_indices("@alice @bob") do |sn, start_index, end_index|
         data = needed.shift
-        sn.should == data[:screen_name]
-        start_index.should == data[:indices].first
-        end_index.should == data[:indices].last
+        expect(sn).to eq(data[:screen_name])
+        expect(start_index).to eq(data[:indices].first)
+        expect(end_index).to eq(data[:indices].last)
       end
-      needed.should == []
+      expect(needed).to eq([])
     end
 
     it "should extract screen name in text with supplementary character" do
-      @extractor.extract_mentioned_screen_names_with_indices("#{[0x10400].pack('U')} @alice").should == [{:screen_name => "alice", :indices => [2, 8]}]
+      expect(@extractor.extract_mentioned_screen_names_with_indices("#{[0x10400].pack('U')} @alice")).to eq([{:screen_name => "alice", :indices => [2, 8]}])
     end
   end
 
   describe "replies" do
     context "should be extracted from" do
       it "should extract from lone name" do
-        @extractor.extract_reply_screen_name("@alice").should == "alice"
+        expect(@extractor.extract_reply_screen_name("@alice")).to eq("alice")
       end
 
       it "should extract from the start" do
-        @extractor.extract_reply_screen_name("@alice reply text").should == "alice"
+        expect(@extractor.extract_reply_screen_name("@alice reply text")).to eq("alice")
       end
 
       it "should extract preceded by a space" do
-        @extractor.extract_reply_screen_name(" @alice reply text").should == "alice"
+        expect(@extractor.extract_reply_screen_name(" @alice reply text")).to eq("alice")
       end
 
       it "should extract preceded by a full-width space" do
-        @extractor.extract_reply_screen_name("#{[0x3000].pack('U')}@alice reply text").should == "alice"
+        expect(@extractor.extract_reply_screen_name("#{[0x3000].pack('U')}@alice reply text")).to eq("alice")
       end
     end
 
     context "should not be extracted from" do
       it "should not be extracted when preceded by text" do
-        @extractor.extract_reply_screen_name("reply @alice text").should == nil
+        expect(@extractor.extract_reply_screen_name("reply @alice text")).to eq(nil)
       end
 
       it "should not be extracted when preceded by puctuation" do
         %w(. / _ - + # ! @).each do |punct|
-          @extractor.extract_reply_screen_name("#{punct}@alice text").should == nil
+          expect(@extractor.extract_reply_screen_name("#{punct}@alice text")).to eq(nil)
         end
       end
     end
@@ -147,7 +149,7 @@ describe Twitter::Extractor do
     context "should accept a block arugment" do
       it "should call the block on match" do
         @extractor.extract_reply_screen_name("@alice") do |sn|
-          sn.should == "alice"
+          expect(sn).to eq("alice")
         end
       end
 
@@ -156,7 +158,7 @@ describe Twitter::Extractor do
         @extractor.extract_reply_screen_name("not a reply") do |sn|
           calls += 1
         end
-        calls.should == 0
+        expect(calls).to eq(0)
       end
     end
   end
@@ -165,19 +167,19 @@ describe Twitter::Extractor do
     describe "matching URLS" do
       TestUrls::VALID.each do |url|
         it "should extract the URL #{url} and prefix it with a protocol if missing" do
-          @extractor.extract_urls(url).first.should include(url)
+          expect(@extractor.extract_urls(url).first).to include(url)
         end
 
         it "should match the URL #{url} when it's embedded in other text" do
           text = "Sweet url: #{url} I found. #awesome"
-          @extractor.extract_urls(text).first.should include(url)
+          expect(@extractor.extract_urls(text).first).to include(url)
         end
       end
     end
 
     describe "invalid URLS" do
       it "does not link urls with invalid domains" do
-        @extractor.extract_urls("http://tld-too-short.x").should == []
+        expect(@extractor.extract_urls("http://tld-too-short.x")).to eq([])
       end
     end
 
@@ -185,19 +187,19 @@ describe Twitter::Extractor do
       TestUrls::TCO.each do |url|
         it "should only extract the t.co URL from the URL #{url}" do
           extracted_urls = @extractor.extract_urls(url)
-          extracted_urls.size.should == 1
+          expect(extracted_urls.size).to eq(1)
           extracted_url = extracted_urls.first
-          extracted_url.should_not == url
-          extracted_url.should == url[0...20]
+          expect(extracted_url).not_to eq(url)
+          expect(extracted_url).to eq(url[0...20])
         end
 
         it "should match the t.co URL from the URL #{url} when it's embedded in other text" do
           text = "Sweet url: #{url} I found. #awesome"
           extracted_urls = @extractor.extract_urls(text)
-          extracted_urls.size.should == 1
+          expect(extracted_urls.size).to eq(1)
           extracted_url = extracted_urls.first
-          extracted_url.should_not == url
-          extracted_url.should == url[0...20]
+          expect(extracted_url).not_to eq(url)
+          expect(extracted_url).to eq(url[0...20])
         end
       end
     end
@@ -208,32 +210,32 @@ describe Twitter::Extractor do
       TestUrls::VALID.each do |url|
         it "should extract the URL #{url} and prefix it with a protocol if missing" do
           extracted_urls = @extractor.extract_urls_with_indices(url)
-          extracted_urls.size.should == 1
+          expect(extracted_urls.size).to eq(1)
           extracted_url = extracted_urls.first
-          extracted_url[:url].should include(url)
-          extracted_url[:indices].first.should == 0
-          extracted_url[:indices].last.should == url.chars.to_a.size
+          expect(extracted_url[:url]).to include(url)
+          expect(extracted_url[:indices].first).to eq(0)
+          expect(extracted_url[:indices].last).to eq(url.chars.to_a.size)
         end
 
         it "should match the URL #{url} when it's embedded in other text" do
           text = "Sweet url: #{url} I found. #awesome"
           extracted_urls = @extractor.extract_urls_with_indices(text)
-          extracted_urls.size.should == 1
+          expect(extracted_urls.size).to eq(1)
           extracted_url = extracted_urls.first
-          extracted_url[:url].should include(url)
-          extracted_url[:indices].first.should == 11
-          extracted_url[:indices].last.should == 11 + url.chars.to_a.size
+          expect(extracted_url[:url]).to include(url)
+          expect(extracted_url[:indices].first).to eq(11)
+          expect(extracted_url[:indices].last).to eq(11 + url.chars.to_a.size)
         end
       end
 
       it "should extract URL in text with supplementary character" do
-        @extractor.extract_urls_with_indices("#{[0x10400].pack('U')} http://twitter.com").should == [{:url => "http://twitter.com", :indices => [2, 20]}]
+        expect(@extractor.extract_urls_with_indices("#{[0x10400].pack('U')} http://twitter.com")).to eq([{:url => "http://twitter.com", :indices => [2, 20]}])
       end
     end
 
     describe "invalid URLS" do
       it "does not link urls with invalid domains" do
-        @extractor.extract_urls_with_indices("http://tld-too-short.x").should == []
+        expect(@extractor.extract_urls_with_indices("http://tld-too-short.x")).to eq([])
       end
     end
 
@@ -241,23 +243,23 @@ describe Twitter::Extractor do
       TestUrls::TCO.each do |url|
         it "should only extract the t.co URL from the URL #{url} and adjust indices correctly" do
           extracted_urls = @extractor.extract_urls_with_indices(url)
-          extracted_urls.size.should == 1
+          expect(extracted_urls.size).to eq(1)
           extracted_url = extracted_urls.first
-          extracted_url[:url].should_not include(url)
-          extracted_url[:url].should include(url[0...20])
-          extracted_url[:indices].first.should == 0
-          extracted_url[:indices].last.should == 20
+          expect(extracted_url[:url]).not_to include(url)
+          expect(extracted_url[:url]).to include(url[0...20])
+          expect(extracted_url[:indices].first).to eq(0)
+          expect(extracted_url[:indices].last).to eq(20)
         end
 
         it "should match the t.co URL from the URL #{url} when it's embedded in other text" do
           text = "Sweet url: #{url} I found. #awesome"
           extracted_urls = @extractor.extract_urls_with_indices(text)
-          extracted_urls.size.should == 1
+          expect(extracted_urls.size).to eq(1)
           extracted_url = extracted_urls.first
-          extracted_url[:url].should_not include(url)
-          extracted_url[:url].should include(url[0...20])
-          extracted_url[:indices].first.should == 11
-          extracted_url[:indices].last.should == 31
+          expect(extracted_url[:url]).not_to include(url)
+          expect(extracted_url[:url]).to include(url[0...20])
+          expect(extracted_url[:indices].first).to eq(11)
+          expect(extracted_url[:indices].last).to eq(31)
         end
       end
     end
@@ -267,11 +269,11 @@ describe Twitter::Extractor do
     context "extracts latin/numeric hashtags" do
       %w(text text123 123text).each do |hashtag|
         it "should extract ##{hashtag}" do
-          @extractor.extract_hashtags("##{hashtag}").should == [hashtag]
+          expect(@extractor.extract_hashtags("##{hashtag}")).to eq([hashtag])
         end
 
         it "should extract ##{hashtag} within text" do
-          @extractor.extract_hashtags("pre-text ##{hashtag} post-text").should == [hashtag]
+          expect(@extractor.extract_hashtags("pre-text ##{hashtag} post-text")).to eq([hashtag])
         end
       end
     end
@@ -280,47 +282,47 @@ describe Twitter::Extractor do
       context "should allow accents" do
         %w(mañana café münchen).each do |hashtag|
           it "should extract ##{hashtag}" do
-            @extractor.extract_hashtags("##{hashtag}").should == [hashtag]
+            expect(@extractor.extract_hashtags("##{hashtag}")).to eq([hashtag])
           end
 
           it "should extract ##{hashtag} within text" do
-            @extractor.extract_hashtags("pre-text ##{hashtag} post-text").should == [hashtag]
+            expect(@extractor.extract_hashtags("pre-text ##{hashtag} post-text")).to eq([hashtag])
           end
         end
 
         it "should not allow the multiplication character" do
-          @extractor.extract_hashtags("#pre#{Twitter::Unicode::U00D7}post").should == ["pre"]
+          expect(@extractor.extract_hashtags("#pre#{Twitter::Unicode::U00D7}post")).to eq(["pre"])
         end
 
         it "should not allow the division character" do
-          @extractor.extract_hashtags("#pre#{Twitter::Unicode::U00F7}post").should == ["pre"]
+          expect(@extractor.extract_hashtags("#pre#{Twitter::Unicode::U00F7}post")).to eq(["pre"])
         end
       end
 
     end
 
     it "should not extract numeric hashtags" do
-      @extractor.extract_hashtags("#1234").should == []
+      expect(@extractor.extract_hashtags("#1234")).to eq([])
     end
 
     it "should extract hashtag followed by punctuations" do
-      @extractor.extract_hashtags("#test1: #test2; #test3\"").should == ["test1", "test2" ,"test3"]
+      expect(@extractor.extract_hashtags("#test1: #test2; #test3\"")).to eq(["test1", "test2" ,"test3"])
     end
   end
 
   describe "hashtags with indices" do
     def match_hashtag_in_text(hashtag, text, offset = 0)
       extracted_hashtags = @extractor.extract_hashtags_with_indices(text)
-      extracted_hashtags.size.should == 1
+      expect(extracted_hashtags.size).to eq(1)
       extracted_hashtag = extracted_hashtags.first
-      extracted_hashtag[:hashtag].should == hashtag
-      extracted_hashtag[:indices].first.should == offset
-      extracted_hashtag[:indices].last.should == offset + hashtag.chars.to_a.size + 1
+      expect(extracted_hashtag[:hashtag]).to eq(hashtag)
+      expect(extracted_hashtag[:indices].first).to eq(offset)
+      expect(extracted_hashtag[:indices].last).to eq(offset + hashtag.chars.to_a.size + 1)
     end
 
     def not_match_hashtag_in_text(text)
       extracted_hashtags = @extractor.extract_hashtags_with_indices(text)
-      extracted_hashtags.size.should == 0
+      expect(extracted_hashtags.size).to eq(0)
     end
 
     context "extracts latin/numeric hashtags" do

--- a/spec/hithighlighter_spec.rb
+++ b/spec/hithighlighter_spec.rb
@@ -18,11 +18,11 @@ describe Twitter::HitHighlighter do
       end
 
       it "should default to <em> tags" do
-        @highlighter.hit_highlight(@original, @hits).should == "Testing this <em>hit</em> highliter"
+        expect(@highlighter.hit_highlight(@original, @hits)).to eq("Testing this <em>hit</em> highliter")
       end
 
       it "should allow tag override" do
-        @highlighter.hit_highlight(@original, @hits, :tag => 'b').should == "Testing this <b>hit</b> highliter"
+        expect(@highlighter.hit_highlight(@original, @hits, :tag => 'b')).to eq("Testing this <b>hit</b> highliter")
       end
     end
 
@@ -32,57 +32,57 @@ describe Twitter::HitHighlighter do
       end
 
       it "should return original when no hits are provided" do
-        @highlighter.hit_highlight(@original).should == @original
+        expect(@highlighter.hit_highlight(@original)).to eq(@original)
       end
 
       it "should highlight one hit" do
-        @highlighter.hit_highlight(@original, hits = [[5, 9]]).should == "Hey! <em>this</em> is a test tweet"
+        expect(@highlighter.hit_highlight(@original, hits = [[5, 9]])).to eq("Hey! <em>this</em> is a test tweet")
       end
 
       it "should highlight two hits" do
-        @highlighter.hit_highlight(@original, hits = [[5, 9], [15, 19]]).should == "Hey! <em>this</em> is a <em>test</em> tweet"
+        expect(@highlighter.hit_highlight(@original, hits = [[5, 9], [15, 19]])).to eq("Hey! <em>this</em> is a <em>test</em> tweet")
       end
 
       it "should correctly highlight first-word hits" do
-        @highlighter.hit_highlight(@original, hits = [[0, 3]]).should == "<em>Hey</em>! this is a test tweet"
+        expect(@highlighter.hit_highlight(@original, hits = [[0, 3]])).to eq("<em>Hey</em>! this is a test tweet")
       end
 
       it "should correctly highlight last-word hits" do
-        @highlighter.hit_highlight(@original, hits = [[20, 25]]).should == "Hey! this is a test <em>tweet</em>"
+        expect(@highlighter.hit_highlight(@original, hits = [[20, 25]])).to eq("Hey! this is a test <em>tweet</em>")
       end
     end
 
     context "with links" do
       it "should highlight with a single link" do
-        @highlighter.hit_highlight("@<a>bcherry</a> this was a test tweet", [[9, 13]]).should == "@<a>bcherry</a> <em>this</em> was a test tweet"
+        expect(@highlighter.hit_highlight("@<a>bcherry</a> this was a test tweet", [[9, 13]])).to eq("@<a>bcherry</a> <em>this</em> was a test tweet")
       end
 
       it "should highlight with link at the end" do
-        @highlighter.hit_highlight("test test <a>test</a>", [[5, 9]]).should == "test <em>test</em> <a>test</a>"
+        expect(@highlighter.hit_highlight("test test <a>test</a>", [[5, 9]])).to eq("test <em>test</em> <a>test</a>")
       end
 
       it "should highlight with a link at the beginning" do
-        @highlighter.hit_highlight("<a>test</a> test test", [[5, 9]]).should == "<a>test</a> <em>test</em> test"
+        expect(@highlighter.hit_highlight("<a>test</a> test test", [[5, 9]])).to eq("<a>test</a> <em>test</em> test")
       end
 
       it "should highlight an entire link" do
-        @highlighter.hit_highlight("test <a>test</a> test", [[5, 9]]).should == "test <a><em>test</em></a> test"
+        expect(@highlighter.hit_highlight("test <a>test</a> test", [[5, 9]])).to eq("test <a><em>test</em></a> test")
       end
 
       it "should highlight within a link" do
-        @highlighter.hit_highlight("test <a>test</a> test", [[6, 8]]).should == "test <a>t<em>es</em>t</a> test"
+        expect(@highlighter.hit_highlight("test <a>test</a> test", [[6, 8]])).to eq("test <a>t<em>es</em>t</a> test")
       end
 
       it "should highlight around a link" do
-        @highlighter.hit_highlight("test <a>test</a> test", [[3, 11]]).should == "tes<em>t <a>test</a> t</em>est"
+        expect(@highlighter.hit_highlight("test <a>test</a> test", [[3, 11]])).to eq("tes<em>t <a>test</a> t</em>est")
       end
 
       it "should fail gracefully with bad hits" do
-        @highlighter.hit_highlight("test test", [[5, 20]]).should == "test <em>test</em>"
+        expect(@highlighter.hit_highlight("test test", [[5, 20]])).to eq("test <em>test</em>")
       end
 
       it "should not mess up with touching tags" do
-        @highlighter.hit_highlight("<a>foo</a><a>foo</a>", [[3,6]]).should == "<a>foo</a><a><em>foo</em></a>"
+        expect(@highlighter.hit_highlight("<a>foo</a><a>foo</a>", [[3,6]])).to eq("<a>foo</a><a><em>foo</em></a>")
       end
 
     end

--- a/spec/regex_spec.rb
+++ b/spec/regex_spec.rb
@@ -5,33 +5,33 @@ describe "Twitter::Regex regular expressions" do
   describe "matching URLS" do
     TestUrls::VALID.each do |url|
       it "should match the URL #{url}" do
-        url.should match_autolink_expression
+        expect(url).to match_autolink_expression
       end
 
       it "should match the URL #{url} when it's embedded in other text" do
         text = "Sweet url: #{url} I found. #awesome"
-        url.should match_autolink_expression_in(text)
+        expect(url).to match_autolink_expression_in(text)
       end
     end
   end
 
   describe "invalid URLS" do
     it "does not link urls with invalid characters" do
-      TestUrls::INVALID.each {|url| url.should_not match_autolink_expression}
+      TestUrls::INVALID.each {|url| expect(url).not_to match_autolink_expression}
     end
   end
 
   describe "matching List names" do
     it "should match if less than 25 characters" do
       name = "Shuffleboard Community"
-      name.length.should < 25
-      name.should match(Twitter::Regex::REGEXEN[:list_name])
+      expect(name.length).to be < 25
+      expect(name).to match(Twitter::Regex::REGEXEN[:list_name])
     end
 
     it "should not match if greater than 25 characters" do
       name = "Most Glorious Shady Meadows Shuffleboard Community"
-      name.length.should > 25
-      name.should match(Twitter::Regex[:list_name])
+      expect(name.length).to be > 25
+      expect(name).to match(Twitter::Regex[:list_name])
     end
 
   end

--- a/spec/rewriter_spec.rb
+++ b/spec/rewriter_spec.rb
@@ -26,8 +26,8 @@ describe Twitter::Rewriter do
       def original_text; "hello @jacob"; end
 
       it "should be rewritten" do
-        @block_args.should == ["@", "jacob", nil]
-        @rewritten_text.should == "hello [rewritten]"
+        expect(@block_args).to eq(["@", "jacob", nil])
+        expect(@rewritten_text).to eq("hello [rewritten]")
       end
     end
 
@@ -35,8 +35,8 @@ describe Twitter::Rewriter do
       def original_text; "@jacob you're cool"; end
 
       it "should be rewritten" do
-        @block_args.should == ["@", "jacob", nil]
-        @rewritten_text.should == "[rewritten] you're cool"
+        expect(@block_args).to eq(["@", "jacob", nil])
+        expect(@rewritten_text).to eq("[rewritten] you're cool")
       end
     end
 
@@ -44,8 +44,8 @@ describe Twitter::Rewriter do
       def original_text; "meet@the beach"; end
 
       it "should not be rewritten" do
-        @block_args.should be_nil
-        @rewritten_text.should == "meet@the beach"
+        expect(@block_args).to be_nil
+        expect(@rewritten_text).to eq("meet@the beach")
       end
     end
 
@@ -53,8 +53,8 @@ describe Twitter::Rewriter do
       def original_text; "great.@jacob"; end
 
       it "should be rewritten" do
-        @block_args.should == ["@", "jacob", nil]
-        @rewritten_text.should == "great.[rewritten]"
+        expect(@block_args).to eq(["@", "jacob", nil])
+        expect(@rewritten_text).to eq("great.[rewritten]")
       end
     end
 
@@ -62,8 +62,8 @@ describe Twitter::Rewriter do
       def original_text; "@jacob&^$%^"; end
 
       it "should be rewritten" do
-        @block_args.should == ["@", "jacob", nil]
-        @rewritten_text.should == "[rewritten]&^$%^"
+        expect(@block_args).to eq(["@", "jacob", nil])
+        expect(@rewritten_text).to eq("[rewritten]&^$%^")
       end
     end
 
@@ -74,8 +74,8 @@ describe Twitter::Rewriter do
       end
 
       it "should be rewritten" do
-        @block_args.should == ["@", @twenty_character_username, nil]
-        @rewritten_text.should == "[rewritten]1"
+        expect(@block_args).to eq(["@", @twenty_character_username, nil])
+        expect(@rewritten_text).to eq("[rewritten]1")
       end
     end
 
@@ -83,8 +83,8 @@ describe Twitter::Rewriter do
       def original_text; "@jacobの"; end
 
       it "should be rewritten" do
-        @block_args.should == ["@", "jacob", nil]
-        @rewritten_text.should == "[rewritten]の"
+        expect(@block_args).to eq(["@", "jacob", nil])
+        expect(@rewritten_text).to eq("[rewritten]の")
       end
     end
 
@@ -92,8 +92,8 @@ describe Twitter::Rewriter do
       def original_text; "あ@jacob"; end
 
       it "should be rewritten" do
-        @block_args.should == ["@", "jacob", nil]
-        @rewritten_text.should == "あ[rewritten]"
+        expect(@block_args).to eq(["@", "jacob", nil])
+        expect(@rewritten_text).to eq("あ[rewritten]")
       end
     end
 
@@ -101,8 +101,8 @@ describe Twitter::Rewriter do
       def original_text; "あ@jacobの"; end
 
       it "should be rewritten" do
-        @block_args.should == ["@", "jacob", nil]
-        @rewritten_text.should == "あ[rewritten]の"
+        expect(@block_args).to eq(["@", "jacob", nil])
+        expect(@rewritten_text).to eq("あ[rewritten]の")
       end
     end
 
@@ -112,8 +112,8 @@ describe Twitter::Rewriter do
       end
 
       it "should be rewritten" do
-        @block_args.should == ["＠", "jacob", nil]
-        @rewritten_text.should == "[rewritten]"
+        expect(@block_args).to eq(["＠", "jacob", nil])
+        expect(@rewritten_text).to eq("[rewritten]")
       end
     end
   end #}}}
@@ -127,8 +127,8 @@ describe Twitter::Rewriter do
       def original_text; "hello @jacob/my-list"; end
 
       it "should be rewritten" do
-        @block_args.should == ["@", "jacob", "/my-list"]
-        @rewritten_text.should == "hello [rewritten]"
+        expect(@block_args).to eq(["@", "jacob", "/my-list"])
+        expect(@rewritten_text).to eq("hello [rewritten]")
       end
     end
 
@@ -136,8 +136,8 @@ describe Twitter::Rewriter do
       def original_text; "hello @jacob/ my-list"; end
 
       it "should not be rewritten" do
-        @block_args.should == ["@", "jacob", nil]
-        @rewritten_text.should == "hello [rewritten]/ my-list"
+        expect(@block_args).to eq(["@", "jacob", nil])
+        expect(@rewritten_text).to eq("hello [rewritten]/ my-list")
       end
     end
 
@@ -145,8 +145,8 @@ describe Twitter::Rewriter do
       def original_text; "hello @/my-list"; end
 
       it "should not be rewritten" do
-        @block_args.should be_nil
-        @rewritten_text.should == "hello @/my-list"
+        expect(@block_args).to be_nil
+        expect(@rewritten_text).to eq("hello @/my-list")
       end
     end
 
@@ -154,8 +154,8 @@ describe Twitter::Rewriter do
       def original_text; "@jacob/my-list"; end
 
       it "should be rewritten" do
-        @block_args.should == ["@", "jacob", "/my-list"]
-        @rewritten_text.should == "[rewritten]"
+        expect(@block_args).to eq(["@", "jacob", "/my-list"])
+        expect(@rewritten_text).to eq("[rewritten]")
       end
     end
 
@@ -163,8 +163,8 @@ describe Twitter::Rewriter do
       def original_text; "meet@jacob/my-list"; end
 
       it "should not be rewritten" do
-        @block_args.should be_nil
-        @rewritten_text.should == "meet@jacob/my-list"
+        expect(@block_args).to be_nil
+        expect(@rewritten_text).to eq("meet@jacob/my-list")
       end
     end
 
@@ -172,8 +172,8 @@ describe Twitter::Rewriter do
       def original_text; "great.@jacob/my-list"; end
 
       it "should be rewritten" do
-        @block_args.should == ["@", "jacob", "/my-list"]
-        @rewritten_text.should == "great.[rewritten]"
+        expect(@block_args).to eq(["@", "jacob", "/my-list"])
+        expect(@rewritten_text).to eq("great.[rewritten]")
       end
     end
 
@@ -181,8 +181,8 @@ describe Twitter::Rewriter do
       def original_text; "@jacob/my-list&^$%^"; end
 
       it "should be rewritten" do
-        @block_args.should == ["@", "jacob", "/my-list"]
-        @rewritten_text.should == "[rewritten]&^$%^"
+        expect(@block_args).to eq(["@", "jacob", "/my-list"])
+        expect(@rewritten_text).to eq("[rewritten]&^$%^")
       end
     end
 
@@ -193,8 +193,8 @@ describe Twitter::Rewriter do
       end
 
       it "should be rewritten" do
-        @block_args.should == ["@", "jacob", "/#{@twentyfive_character_list}"]
-        @rewritten_text.should == "[rewritten]12345"
+        expect(@block_args).to eq(["@", "jacob", "/#{@twentyfive_character_list}"])
+        expect(@rewritten_text).to eq("[rewritten]12345")
       end
     end
   end #}}}
@@ -208,8 +208,8 @@ describe Twitter::Rewriter do
       def original_text; "#123"; end
 
       it "should not be rewritten" do
-        @block_args.should be_nil
-        @rewritten_text.should == "#123"
+        expect(@block_args).to be_nil
+        expect(@rewritten_text).to eq("#123")
       end
     end
 
@@ -217,8 +217,8 @@ describe Twitter::Rewriter do
       def original_text; "#ab1d"; end
 
       it "should be rewritten" do
-        @block_args.should == ["#", "ab1d"]
-        @rewritten_text.should == "[rewritten]"
+        expect(@block_args).to eq(["#", "ab1d"])
+        expect(@rewritten_text).to eq("[rewritten]")
       end
     end
 
@@ -226,8 +226,8 @@ describe Twitter::Rewriter do
       def original_text; "#a_b_c_d"; end
 
       it "should be rewritten" do
-        @block_args.should == ["#", "a_b_c_d"]
-        @rewritten_text.should == "[rewritten]"
+        expect(@block_args).to eq(["#", "a_b_c_d"])
+        expect(@rewritten_text).to eq("[rewritten]")
       end
     end
 
@@ -235,8 +235,8 @@ describe Twitter::Rewriter do
       def original_text; "ab#cd"; end
 
       it "should not be rewritten" do
-        @block_args.should be_nil
-        @rewritten_text.should == "ab#cd"
+        expect(@block_args).to be_nil
+        expect(@rewritten_text).to eq("ab#cd")
       end
     end
 
@@ -244,8 +244,8 @@ describe Twitter::Rewriter do
       def original_text; "#2ab"; end
 
       it "should be rewritten" do
-        @block_args.should == ["#", "2ab"]
-        @rewritten_text.should == "[rewritten]"
+        expect(@block_args).to eq(["#", "2ab"])
+        expect(@rewritten_text).to eq("[rewritten]")
       end
     end
 
@@ -253,8 +253,8 @@ describe Twitter::Rewriter do
       def original_text; "I'm frickin' awesome #ab #cd #ef"; end
 
       it "rewrites each hashtag" do
-        @block_args.should == [["#", "ab"], ["#", "cd"], ["#", "ef"]]
-        @rewritten_text.should == "I'm frickin' awesome [rewritten] [rewritten] [rewritten]"
+        expect(@block_args).to eq([["#", "ab"], ["#", "cd"], ["#", "ef"]])
+        expect(@rewritten_text).to eq("I'm frickin' awesome [rewritten] [rewritten] [rewritten]")
       end
     end
 
@@ -262,8 +262,8 @@ describe Twitter::Rewriter do
       def original_text; "ok, great.#abc"; end
 
       it "should be rewritten" do
-        @block_args.should == ["#", "abc"]
-        @rewritten_text.should == "ok, great.[rewritten]"
+        expect(@block_args).to eq(["#", "abc"])
+        expect(@rewritten_text).to eq("ok, great.[rewritten]")
       end
     end
 
@@ -271,8 +271,8 @@ describe Twitter::Rewriter do
       def original_text; "&#nbsp;"; end
 
       it "should not be rewritten" do
-        @block_args.should be_nil
-        @rewritten_text.should == "&#nbsp;"
+        expect(@block_args).to be_nil
+        expect(@rewritten_text).to eq("&#nbsp;")
       end
     end
 
@@ -280,8 +280,8 @@ describe Twitter::Rewriter do
       def original_text; "#great!"; end
 
       it "should be rewritten, but should not include the !" do
-        @block_args.should == ["#", "great"];
-        @rewritten_text.should == "[rewritten]!"
+        expect(@block_args).to eq(["#", "great"]);
+        expect(@rewritten_text).to eq("[rewritten]!")
       end
     end
 
@@ -289,8 +289,8 @@ describe Twitter::Rewriter do
       def original_text; "#twj_devの"; end
 
       it "should be rewritten" do
-        @block_args.should == ["#", "twj_devの"];
-        @rewritten_text.should == "[rewritten]"
+        expect(@block_args).to eq(["#", "twj_devの"]);
+        expect(@rewritten_text).to eq("[rewritten]")
       end
     end
 
@@ -298,8 +298,8 @@ describe Twitter::Rewriter do
       def original_text; "#{[0x3000].pack('U')}#twj_dev"; end
 
       it "should be rewritten" do
-        @block_args.should == ["#", "twj_dev"];
-        @rewritten_text.should == "　[rewritten]"
+        expect(@block_args).to eq(["#", "twj_dev"]);
+        expect(@rewritten_text).to eq("　[rewritten]")
       end
     end
 
@@ -307,8 +307,8 @@ describe Twitter::Rewriter do
       def original_text; "#twj_dev#{[0x3000].pack('U')}"; end
 
       it "should be rewritten" do
-        @block_args.should == ["#", "twj_dev"];
-        @rewritten_text.should == "[rewritten]　"
+        expect(@block_args).to eq(["#", "twj_dev"]);
+        expect(@rewritten_text).to eq("[rewritten]　")
       end
     end
 
@@ -316,8 +316,8 @@ describe Twitter::Rewriter do
       def original_text; "#{[0xFF03].pack('U')}twj_dev"; end
 
       it "should be rewritten" do
-        @block_args.should == ["＃", "twj_dev"];
-        @rewritten_text.should == "[rewritten]"
+        expect(@block_args).to eq(["＃", "twj_dev"]);
+        expect(@rewritten_text).to eq("[rewritten]")
       end
     end
 
@@ -328,8 +328,8 @@ describe Twitter::Rewriter do
       end
 
       it "should be rewritten" do
-        @block_args.should == ["#", "éhashtag"];
-        @rewritten_text.should == "[rewritten]"
+        expect(@block_args).to eq(["#", "éhashtag"]);
+        expect(@rewritten_text).to eq("[rewritten]")
       end
     end
   end #}}}
@@ -345,8 +345,8 @@ describe Twitter::Rewriter do
       def original_text; "On my search engine #{url} I found good links."; end
 
       it "should be rewritten" do
-        @block_args.should == [url];
-        @rewritten_text.should == "On my search engine [rewritten] I found good links."
+        expect(@block_args).to eq([url]);
+        expect(@rewritten_text).to eq("On my search engine [rewritten] I found good links.")
       end
     end
 
@@ -354,8 +354,8 @@ describe Twitter::Rewriter do
       def original_text; "いまなにしてる#{url}いまなにしてる"; end
 
       it "should be rewritten" do
-        @block_args.should == [url];
-        @rewritten_text.should == "いまなにしてる[rewritten]いまなにしてる"
+        expect(@block_args).to eq([url]);
+        expect(@rewritten_text).to eq("いまなにしてる[rewritten]いまなにしてる")
       end
     end
 
@@ -363,16 +363,16 @@ describe Twitter::Rewriter do
       def original_text; "I found a neatness (#{url})"; end
 
       it "should be rewritten" do
-        @block_args.should == [url];
-        @rewritten_text.should == "I found a neatness ([rewritten])"
+        expect(@block_args).to eq([url]);
+        expect(@rewritten_text).to eq("I found a neatness ([rewritten])")
       end
 
       context "when the URL ends with a slash;" do
         def url; "http://www.google.com/"; end
 
         it "should be rewritten" do
-          @block_args.should == [url];
-          @rewritten_text.should == "I found a neatness ([rewritten])"
+          expect(@block_args).to eq([url]);
+          expect(@rewritten_text).to eq("I found a neatness ([rewritten])")
         end
       end
 
@@ -380,8 +380,8 @@ describe Twitter::Rewriter do
         def url; "http://www.google.com/fsdfasdf"; end
 
         it "should be rewritten" do
-          @block_args.should == [url];
-          @rewritten_text.should == "I found a neatness ([rewritten])"
+          expect(@block_args).to eq([url]);
+          expect(@rewritten_text).to eq("I found a neatness ([rewritten])")
         end
       end
     end
@@ -390,16 +390,16 @@ describe Twitter::Rewriter do
       def original_text; "I found a neatness (#{url})"; end
 
       it "should be rewritten" do
-        @block_args.should == [url];
-        @rewritten_text.should == "I found a neatness ([rewritten])"
+        expect(@block_args).to eq([url]);
+        expect(@rewritten_text).to eq("I found a neatness ([rewritten])")
       end
 
       context "wikipedia" do
         def url; "http://en.wikipedia.org/wiki/Madonna_(artist)"; end
 
         it "should be rewritten" do
-          @block_args.should == [url];
-          @rewritten_text.should == "I found a neatness ([rewritten])"
+          expect(@block_args).to eq([url]);
+          expect(@rewritten_text).to eq("I found a neatness ([rewritten])")
         end
       end
 
@@ -407,8 +407,8 @@ describe Twitter::Rewriter do
         def url; "http://msdn.com/S(deadbeef)/page.htm"; end
 
         it "should be rewritten" do
-          @block_args.should == [url];
-          @rewritten_text.should == "I found a neatness ([rewritten])"
+          expect(@block_args).to eq([url]);
+          expect(@rewritten_text).to eq("I found a neatness ([rewritten])")
         end
       end
 
@@ -416,8 +416,8 @@ describe Twitter::Rewriter do
         def url; "http://example.com/i_has_a_("; end
 
         it "should be rewritten" do
-          @block_args.should == ["http://example.com/i_has_a_"];
-          @rewritten_text.should == "I found a neatness ([rewritten]()"
+          expect(@block_args).to eq(["http://example.com/i_has_a_"]);
+          expect(@rewritten_text).to eq("I found a neatness ([rewritten]()")
         end
       end
 
@@ -425,8 +425,8 @@ describe Twitter::Rewriter do
         def url; "http://foo.bar.com/foo_(\")_bar" end
 
         it "should be rewritten" do
-          @block_args.should == ["http://foo.bar.com/foo_"];
-          @rewritten_text.should == "I found a neatness ([rewritten](\")_bar)"
+          expect(@block_args).to eq(["http://foo.bar.com/foo_"]);
+          expect(@rewritten_text).to eq("I found a neatness ([rewritten](\")_bar)")
         end
       end
 
@@ -434,8 +434,8 @@ describe Twitter::Rewriter do
         def url; 'http://x.xx.com/("style="color:red"onmouseover="alert(1)' end
 
         it "should be rewritten" do
-          @block_args.should == ["http://x.xx.com/"];
-          @rewritten_text.should == 'I found a neatness ([rewritten]("style="color:red"onmouseover="alert(1))'
+          expect(@block_args).to eq(["http://x.xx.com/"]);
+          expect(@rewritten_text).to eq('I found a neatness ([rewritten]("style="color:red"onmouseover="alert(1))')
         end
       end
     end
@@ -444,17 +444,17 @@ describe Twitter::Rewriter do
       def original_text; "Check this out @hoverbird:#{url}"; end
 
       it "should be rewritten" do
-        @block_args.should == [url];
-        @rewritten_text.should == "Check this out @hoverbird:[rewritten]"
+        expect(@block_args).to eq([url]);
+        expect(@rewritten_text).to eq("Check this out @hoverbird:[rewritten]")
       end
     end
 
     context "with a URL ending in allowed punctuation" do
       it "does not consume ending punctuation" do
         %w| ? ! , . : ; ] ) } = \ ' |.each do |char|
-          Twitter::Rewriter.rewrite_urls("#{url}#{char}") do |url|
-            url.should == url; "[rewritten]"
-          end.should == "[rewritten]#{char}"
+          expect(Twitter::Rewriter.rewrite_urls("#{url}#{char}") do |url|
+            expect(url).to eq(url); "[rewritten]"
+          end).to eq("[rewritten]#{char}")
         end
       end
     end
@@ -462,9 +462,9 @@ describe Twitter::Rewriter do
     context "with a URL preceded in forbidden characters" do
       it "should be rewritten" do
         %w| \ ' / ! = |.each do |char|
-          Twitter::Rewriter.rewrite_urls("#{char}#{url}") do |url|
+          expect(Twitter::Rewriter.rewrite_urls("#{char}#{url}") do |url|
             "[rewritten]" # should not be called here.
-          end.should == "#{char}[rewritten]"
+          end).to eq("#{char}[rewritten]")
         end
       end
     end
@@ -473,8 +473,8 @@ describe Twitter::Rewriter do
       def original_text; "<link rel='true'>#{url}</link>"; end
 
       it "should be rewritten" do
-        @block_args.should == [url];
-        @rewritten_text.should == "<link rel='true'>[rewritten]</link>"
+        expect(@block_args).to eq([url]);
+        expect(@rewritten_text).to eq("<link rel='true'>[rewritten]</link>")
       end
     end
 
@@ -482,8 +482,8 @@ describe Twitter::Rewriter do
       def original_text; "http://www.links.org link at start of page, link at end http://www.foo.org"; end
 
       it "should autolink each one" do
-        @block_args.should == [["http://www.links.org"], ["http://www.foo.org"]];
-        @rewritten_text.should == "[rewritten] link at start of page, link at end [rewritten]"
+        expect(@block_args).to eq([["http://www.links.org"], ["http://www.foo.org"]]);
+        expect(@rewritten_text).to eq("[rewritten] link at start of page, link at end [rewritten]")
       end
     end
 
@@ -491,8 +491,8 @@ describe Twitter::Rewriter do
       def original_text; "http://foo.com https://bar.com http://mail.foobar.org"; end
 
       it "should autolink each one, in the proper order" do
-        @block_args.should == [["http://foo.com"], ["https://bar.com"], ["http://mail.foobar.org"]];
-        @rewritten_text.should == "[rewritten] [rewritten] [rewritten]"
+        expect(@block_args).to eq([["http://foo.com"], ["https://bar.com"], ["http://mail.foobar.org"]]);
+        expect(@rewritten_text).to eq("[rewritten] [rewritten] [rewritten]")
       end
     end
 
@@ -500,8 +500,8 @@ describe Twitter::Rewriter do
       def original_text; "Yahoo integriert Facebook http://golem.mobi/0912/71607.html"; end
 
       it "should autolink it" do
-        @block_args.should == ["http://golem.mobi/0912/71607.html"]
-        @rewritten_text.should == "Yahoo integriert Facebook [rewritten]"
+        expect(@block_args).to eq(["http://golem.mobi/0912/71607.html"])
+        expect(@rewritten_text).to eq("Yahoo integriert Facebook [rewritten]")
       end
     end
 
@@ -509,8 +509,8 @@ describe Twitter::Rewriter do
       def original_text; "I like www.foobar.com dudes"; end
 
       it "does not link at all" do
-        @block_args.should be_nil
-        @rewritten_text.should == "I like www.foobar.com dudes"
+        expect(@block_args).to be_nil
+        expect(@rewritten_text).to eq("I like www.foobar.com dudes")
       end
     end
 
@@ -519,8 +519,8 @@ describe Twitter::Rewriter do
         def original_text; 'http://x.xx.com/@"style="color:pink"onmouseover=alert(1)//'; end
 
         it "should not allow XSS follwing @" do
-          @block_args.should == ["http://x.xx.com/"]
-          @rewritten_text.should == '[rewritten]@"style="color:pink"onmouseover=alert(1)//'
+          expect(@block_args).to eq(["http://x.xx.com/"])
+          expect(@rewritten_text).to eq('[rewritten]@"style="color:pink"onmouseover=alert(1)//')
         end
       end
 
@@ -528,8 +528,8 @@ describe Twitter::Rewriter do
         def original_text; "http://example.com/@foobar"; end
 
         it "should link url" do
-          @block_args.should == ["http://example.com/@foobar"]
-          @rewritten_text.should == "[rewritten]"
+          expect(@block_args).to eq(["http://example.com/@foobar"])
+          expect(@rewritten_text).to eq("[rewritten]")
         end
       end
 
@@ -537,8 +537,8 @@ describe Twitter::Rewriter do
         def original_text; "http://example.com/@foobar/"; end
 
         it "should not link the username but link full url" do
-          @block_args.should == ["http://example.com/@foobar/"]
-          @rewritten_text.should == "[rewritten]"
+          expect(@block_args).to eq(["http://example.com/@foobar/"])
+          expect(@rewritten_text).to eq("[rewritten]")
         end
       end
     end

--- a/spec/twitter_text_spec.rb
+++ b/spec/twitter_text_spec.rb
@@ -13,9 +13,9 @@ if major.to_i == 1 && minor.to_i < 9
     end
 
     it "should raise with invalid KCODE on Ruby < 1.9" do
-      lambda do
+      expect do
         require 'twitter-text'
-      end.should raise_error
+      end.to raise_error
     end
   end
 end

--- a/spec/unicode_spec.rb
+++ b/spec/unicode_spec.rb
@@ -4,28 +4,28 @@ require File.dirname(__FILE__) + '/spec_helper'
 describe Twitter::Unicode do
 
   it "should lazy-init constants" do
-    Twitter::Unicode.const_defined?(:UFEB6).should == false
-    Twitter::Unicode::UFEB6.should_not be_nil
-    Twitter::Unicode::UFEB6.should be_kind_of(String)
-    Twitter::Unicode.const_defined?(:UFEB6).should == true
+    expect(Twitter::Unicode.const_defined?(:UFEB6)).to eq(false)
+    expect(Twitter::Unicode::UFEB6).not_to be_nil
+    expect(Twitter::Unicode::UFEB6).to be_kind_of(String)
+    expect(Twitter::Unicode.const_defined?(:UFEB6)).to eq(true)
   end
 
   it "should return corresponding character" do
-    Twitter::Unicode::UFEB6.should == [0xfeb6].pack('U')
+    expect(Twitter::Unicode::UFEB6).to eq([0xfeb6].pack('U'))
   end
 
   it "should allow lowercase notation" do
-    Twitter::Unicode::Ufeb6.should == Twitter::Unicode::UFEB6
-    Twitter::Unicode::Ufeb6.should === Twitter::Unicode::UFEB6
+    expect(Twitter::Unicode::Ufeb6).to eq(Twitter::Unicode::UFEB6)
+    expect(Twitter::Unicode::Ufeb6).to be === Twitter::Unicode::UFEB6
   end
 
   it "should allow underscore notation" do
-    Twitter::Unicode::U_FEB6.should == Twitter::Unicode::UFEB6
-    Twitter::Unicode::U_FEB6.should === Twitter::Unicode::UFEB6
+    expect(Twitter::Unicode::U_FEB6).to eq(Twitter::Unicode::UFEB6)
+    expect(Twitter::Unicode::U_FEB6).to be === Twitter::Unicode::UFEB6
   end
 
   it "should raise on invalid codepoints" do
-    lambda { Twitter::Unicode::FFFFFF }.should raise_error(NameError)
+    expect { Twitter::Unicode::FFFFFF }.to raise_error(NameError)
   end
 
 end

--- a/spec/validation_spec.rb
+++ b/spec/validation_spec.rb
@@ -8,36 +8,36 @@ end
 describe Twitter::Validation do
 
   it "should disallow invalid BOM character" do
-    TestValidation.new.tweet_invalid?("Bom:#{Twitter::Unicode::UFFFE}").should == :invalid_characters
-    TestValidation.new.tweet_invalid?("Bom:#{Twitter::Unicode::UFEFF}").should == :invalid_characters
+    expect(TestValidation.new.tweet_invalid?("Bom:#{Twitter::Unicode::UFFFE}")).to eq(:invalid_characters)
+    expect(TestValidation.new.tweet_invalid?("Bom:#{Twitter::Unicode::UFEFF}")).to eq(:invalid_characters)
   end
 
   it "should disallow invalid U+FFFF character" do
-    TestValidation.new.tweet_invalid?("Bom:#{Twitter::Unicode::UFFFF}").should == :invalid_characters
+    expect(TestValidation.new.tweet_invalid?("Bom:#{Twitter::Unicode::UFFFF}")).to eq(:invalid_characters)
   end
 
   it "should disallow direction change characters" do
     [0x202A, 0x202B, 0x202C, 0x202D, 0x202E].map{|cp| [cp].pack('U') }.each do |char|
-      TestValidation.new.tweet_invalid?("Invalid:#{char}").should == :invalid_characters
+      expect(TestValidation.new.tweet_invalid?("Invalid:#{char}")).to eq(:invalid_characters)
     end
   end
 
   it "should disallow non-Unicode" do
-    TestValidation.new.tweet_invalid?("not-Unicode:\xfff0").should == :invalid_characters
+    expect(TestValidation.new.tweet_invalid?("not-Unicode:\xfff0")).to eq(:invalid_characters)
   end
 
   it "should allow <= 140 combined accent characters" do
     char = [0x65, 0x0301].pack('U')
-    TestValidation.new.tweet_invalid?(char * 139).should == false
-    TestValidation.new.tweet_invalid?(char * 140).should == false
-    TestValidation.new.tweet_invalid?(char * 141).should == :too_long
+    expect(TestValidation.new.tweet_invalid?(char * 139)).to eq(false)
+    expect(TestValidation.new.tweet_invalid?(char * 140)).to eq(false)
+    expect(TestValidation.new.tweet_invalid?(char * 141)).to eq(:too_long)
   end
 
   it "should allow <= 140 multi-byte characters" do
     char = [ 0x1d106 ].pack('U')
-    TestValidation.new.tweet_invalid?(char * 139).should == false
-    TestValidation.new.tweet_invalid?(char * 140).should == false
-    TestValidation.new.tweet_invalid?(char * 141).should == :too_long
+    expect(TestValidation.new.tweet_invalid?(char * 139)).to eq(false)
+    expect(TestValidation.new.tweet_invalid?(char * 140)).to eq(false)
+    expect(TestValidation.new.tweet_invalid?(char * 141)).to eq(:too_long)
   end
 
 end


### PR DESCRIPTION
...matchers.

This conversion is done by Transpec 1.13.1 with the following command:
    transpec
- 351 conversions
  from: obj.should
    to: expect(obj).to
- 220 conversions
  from: == expected
    to: eq(expected)
- 28 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 2 conversions
  from: === expected
    to: be === expected
- 2 conversions
  from: lambda { }.should
    to: expect { }.to
- 1 conversion
  from: < expected
    to: be < expected
- 1 conversion
  from: > expected
    to: be > expected
