### PR TITLE
Replace entity[:indices] calls with entity.indices

### DIFF
--- a/lib/twitter-text/autolink.rb
+++ b/lib/twitter-text/autolink.rb
@@ -326,7 +326,7 @@ module Twitter
     end
 
     def link_to_hashtag(entity, chars, options = {})
-      hash = chars[entity[:indices].first]
+      hash = chars[entity.indices.first]
       hashtag = entity[:hashtag]
       hashtag = yield(hashtag) if block_given?
       hashtag_class = options[:hashtag_class]
@@ -352,7 +352,7 @@ module Twitter
     end
 
     def link_to_cashtag(entity, chars, options = {})
-      dollar = chars[entity[:indices].first]
+      dollar = chars[entity.indices.first]
       cashtag = entity[:cashtag]
       cashtag = yield(cashtag) if block_given?
 
@@ -376,7 +376,7 @@ module Twitter
       chunk = name.dup
       chunk = yield(chunk) if block_given?
 
-      at = chars[entity[:indices].first]
+      at = chars[entity.indices.first]
 
       html_attrs = options[:html_attrs].dup
 

--- a/lib/twitter-text/extractor.rb
+++ b/lib/twitter-text/extractor.rb
@@ -51,11 +51,11 @@ module Twitter
     # This returns a new array with no overlapping entities.
     def remove_overlapping_entities(entities)
       # sort by start index
-      entities = entities.sort_by{|entity| entity[:indices].first}
+      entities = entities.sort_by{|entity| entity.indices.first}
 
       # remove duplicates
       prev = nil
-      entities.reject!{|entity| (prev && prev[:indices].last > entity[:indices].first) || (prev = entity) && false}
+      entities.reject!{|entity| (prev && prev[:indices].last > entity.indices.first) || (prev = entity) && false}
       entities
     end
 

--- a/lib/twitter-text/rewriter.rb
+++ b/lib/twitter-text/rewriter.rb
@@ -5,13 +5,13 @@ module Twitter
       chars = text.to_s.to_char_a
 
       # sort by start index
-      entities = entities.sort_by{|entity| entity[:indices].first}
+      entities = entities.sort_by{|entity| entity.indices.first}
 
       result = []
       last_index = entities.inject(0) do |index, entity|
-        result << chars[index...entity[:indices].first]
+        result << chars[index...entity.indices.first]
         result << yield(entity, chars)
-        entity[:indices].last
+        entity.indices.last
       end
       result << chars[last_index..-1]
 
@@ -31,7 +31,7 @@ module Twitter
     def rewrite_usernames_or_lists(text)
       entities = Extractor.extract_mentions_or_lists_with_indices(text)
       rewrite_entities(text, entities) do |entity, chars|
-        at = chars[entity[:indices].first]
+        at = chars[entity.indices.first]
         list_slug = entity[:list_slug]
         list_slug = nil if list_slug.empty?
         yield(at, entity[:screen_name], list_slug)
@@ -42,7 +42,7 @@ module Twitter
     def rewrite_hashtags(text)
       entities = Extractor.extract_hashtags_with_indices(text)
       rewrite_entities(text, entities) do |entity, chars|
-        hash = chars[entity[:indices].first]
+        hash = chars[entity.indices.first]
         yield(hash, entity[:hashtag])
       end
     end


### PR DESCRIPTION
Retrieving indices via entity[:indices] is deprecated in favor of the entity#indices method. This cleans up deprecation notices such as the following:

```
twitter-text-1.10.0/lib/twitter-text/rewriter.rb:14:in `block in rewrite_entities': [DEPRECATION] #[:indices] is deprecated. Use #indices to fetch the value.
```
